### PR TITLE
feat: exempt GYFI token from deprecation

### DIFF
--- a/envio/common/deprecated.ts
+++ b/envio/common/deprecated.ts
@@ -60,6 +60,10 @@ export async function isDeprecatedStream(context: DeprecatedStreamContext, strea
  * Checks if the token address is exempted from deprecation rules.
  */
 function isExemptedAsset(asset: Envio.Address): boolean {
-  const EXEMPTED_ASSETS = ["0xbea586a167853adddef12818f264f1f9823fbc18", "0x111123ea4cee28cf010703593a8a2a3bbb91756c"];
+  const EXEMPTED_ASSETS = [
+    "0xbea586a167853adddef12818f264f1f9823fbc18", // esEXA on Optimism (10)
+    "0x111123ea4cee28cf010703593a8a2a3bbb91756c", // ARA on Base (8453)
+    "0x70c4430f9d98b4184a4ef3e44ce10c320a8b7383", // GYFI on Ethereum (1)
+  ];
   return EXEMPTED_ASSETS.includes(asset);
 }

--- a/graph/common/deprecated.ts
+++ b/graph/common/deprecated.ts
@@ -52,8 +52,9 @@ export function isDeprecatedContract(event: ethereum.Event, protocol: string, as
  * Checks if the token address is exempted from deprecation rules.
  */
 function isExemptedAsset(asset: Address): boolean {
-  const EXEMPTED_ASSETS = new Array<string>(1);
-  EXEMPTED_ASSETS[0] = "0xbea586a167853adddef12818f264f1f9823fbc18"; // esEXA
-  EXEMPTED_ASSETS[1] = "0x111123ea4cee28cf010703593a8a2a3bbb91756c"; // ARA
+  const EXEMPTED_ASSETS = new Array<string>(3);
+  EXEMPTED_ASSETS[0] = "0xbea586a167853adddef12818f264f1f9823fbc18"; // esEXA on Optimism (10)
+  EXEMPTED_ASSETS[1] = "0x111123ea4cee28cf010703593a8a2a3bbb91756c"; // ARA on Base (8453)
+  EXEMPTED_ASSETS[2] = "0x70c4430f9d98b4184a4ef3e44ce10c320a8b7383"; // GYFI on Ethereum (1)
   return EXEMPTED_ASSETS.includes(asset.toHexString());
 }


### PR DESCRIPTION
Adds GYFI token on Ethereum to the deprecation exemption list. This allows GYFI streams created after Sep 19, 2025 to continue being indexed alongside the existing exemptions for esEXA and ARA.

Also improves documentation by adding chain names and IDs to all exempted token comments.

Closes #240

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded the exempted assets list to include three tokens: esEXA on Optimism, ARA on Base, and GYFI on Ethereum
  * Added clarifying comments for each exempted asset entry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->