### PR TITLE
refactor: reorder YAML config field definitions for consistency

### DIFF
--- a/cli/commands/codegen/envio-config/networks.ts
+++ b/cli/commands/codegen/envio-config/networks.ts
@@ -20,12 +20,13 @@ export function createNetworks(protocol: Indexer.Protocol): EnvioConfig.Network[
       : undefined;
     const rpc = getRPCs(chain.id, chain.config?.rpcOnly);
 
+    // Order matters for readability in the YAML config file.
     networks.push({
-      contracts,
-      hypersync_config,
       id: chain.id,
-      rpc,
       start_block: 0,
+      hypersync_config,
+      rpc,
+      contracts,
     });
   }
 

--- a/envio/airdrops/config.yaml
+++ b/envio/airdrops/config.yaml
@@ -116,7 +116,14 @@ contracts:
       - event: "ClaimLTWithVesting"
       - event: "LowerMinFeeUSD"
 networks:
-  - contracts:
+  - id: 2741
+    start_block: 73620
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xe2c0c3e0ff10df4485a2dcbbdd1d002a40446164"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 73620
@@ -140,14 +147,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 2741
+  - id: 42161
+    start_block: 161026555
     rpc:
+      - for: "fallback"
+        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 73620
-  - contracts:
+        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x237400ef5a41886a75b0e036228221df075b3b80"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 161026555
@@ -175,16 +184,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 42161
+  - id: 43114
+    start_block: 41023959
     rpc:
       - for: "fallback"
-        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 161026555
-  - contracts:
+        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x4849e797d7aab20fcc8f807efafdfff98a83412e"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 41023959
@@ -212,16 +221,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 43114
+  - id: 8453
+    start_block: 8026894
     rpc:
       - for: "fallback"
-        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 41023959
-  - contracts:
+        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x5545c8e7c3e1f74adc98e518f2e8d23a002c4412"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 8026894
@@ -249,16 +258,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 8453
+  - id: 81457
+    start_block: 244740
     rpc:
       - for: "fallback"
-        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 8026894
-  - contracts:
+        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x92fc05e49c27884d554d98a5c01ff0894a9dc29a"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 244740
@@ -286,16 +295,14 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 81457
+  - id: 80094
+    start_block: 780306
     rpc:
-      - for: "fallback"
-        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 244740
-  - contracts:
+        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x7868af143cc5e6cd03f9b4f5cdd2832695a85d6b"
         name: "SablierMerkleFactory_v1_3"
         start_block: 780306
@@ -314,14 +321,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 80094
+  - id: 56
+    start_block: 34438438
     rpc:
+      - for: "fallback"
+        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 780306
-  - contracts:
+        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x434d73465aac4125d204a6637eb6c579d8d69f48"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 34438438
@@ -349,16 +358,11 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 56
-    rpc:
-      - for: "fallback"
-        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 34438438
-  - contracts:
+  - id: 88888
+    start_block: 19125620
+    hypersync_config:
+      url: "https://chiliz.hypersync.xyz"
+    contracts:
       - address: "0x92fc05e49c27884d554d98a5c01ff0894a9dc29a"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 19125620
@@ -382,11 +386,14 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    hypersync_config:
-      url: "https://chiliz.hypersync.xyz"
-    id: 88888
-    start_block: 19125620
-  - contracts:
+  - id: 100
+    start_block: 31491795
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x777f66477ff83ababadf39a3f22a8cc3aee43765"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 31491795
@@ -414,14 +421,9 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 100
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 31491795
-  - contracts:
+  - id: 999
+    start_block: 8665370
+    contracts:
       - address: "0xe0548364372f3b842e6f89e2dac2e53b5ea0a35b"
         name: "SablierMerkleFactory_v1_3"
         start_block: 8665370
@@ -440,9 +442,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 999
-    start_block: 8665370
-  - contracts:
+  - id: 59144
+    start_block: 8688454
+    rpc:
+      - for: "fallback"
+        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x35e9c3445a039b258eb7112a5eea259a825e8ac0"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 8688454
@@ -466,16 +475,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 59144
+  - id: 1
+    start_block: 18811605
     rpc:
       - for: "fallback"
-        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 8688454
-  - contracts:
+        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x1a272b596b10f02931480bc7a3617db4a8d154e3"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 18811605
@@ -503,16 +512,9 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 1
-    rpc:
-      - for: "fallback"
-        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 18811605
-  - contracts:
+  - id: 34443
+    start_block: 11343396
+    contracts:
       - address: "0x0fd01dd30f96a15de6afad5627d45ef94752460a"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 11343396
@@ -536,9 +538,14 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 34443
-    start_block: 11343396
-  - contracts:
+  - id: 143
+    start_block: 34590049
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xab15e653cd3bbce7b7412f81056a450bc0f2e7b9"
         name: "SablierFactoryMerkleInstant_v2_0"
         start_block: 34590049
@@ -551,14 +558,9 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 143
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 34590049
-  - contracts:
+  - id: 2818
+    start_block: 45862
+    contracts:
       - address: "0x5e73bb96493c10919204045fcdb639d35ad859f8"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 45862
@@ -582,9 +584,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 2818
-    start_block: 45862
-  - contracts:
+  - id: 10
+    start_block: 113621901
+    rpc:
+      - for: "fallback"
+        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x044ec80fbec40f0ee7e7b3856828170971796c19"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 113621901
@@ -612,16 +621,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 10
+  - id: 137
+    start_block: 51245836
     rpc:
       - for: "fallback"
-        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 113621901
-  - contracts:
+        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf4906225e783fb8977410bdbfb960cabed6c2ef4"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 51245836
@@ -649,16 +658,14 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 137
+  - id: 146
+    start_block: 43945441
     rpc:
-      - for: "fallback"
-        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 51245836
-  - contracts:
+        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xbd73389cbdd4f31f374f2815ecb7f9dec0f124d3"
         name: "SablierMerkleFactory_v1_3"
         start_block: 43945441
@@ -677,14 +684,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 146
+  - id: 534352
+    start_block: 1675340
     rpc:
+      - for: "fallback"
+        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 43945441
-  - contracts:
+        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xb3ade5463000e6c0d376e7d7570f372ebf98bdaf"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 1675340
@@ -712,25 +721,23 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 534352
-    rpc:
-      - for: "fallback"
-        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 1675340
-  - contracts:
+  - id: 50104
+    start_block: 11290094
+    contracts:
       - address: "0x9d4923e2ff0b9dadc447a89f528760928f84d0f7"
         name: "SablierMerkleFactory_v1_3"
         start_block: 11290094
       - name: "SablierMerkleInstant_v1_3"
       - name: "SablierMerkleLL_v1_3"
       - name: "SablierMerkleLT_v1_3"
-    id: 50104
-    start_block: 11290094
-  - contracts:
+  - id: 5330
+    start_block: 799582
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf60beadefbeb98c927e13c4165bca7d85ba32cb2"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 2896477
@@ -754,14 +761,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 5330
+  - id: 130
+    start_block: 13885193
     rpc:
+      - for: "fallback"
+        url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 799582
-  - contracts:
+        url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xc6fc028e988d158c52aa2e38cdd6f969aa14bdcd"
         name: "SablierMerkleFactory_v1_3"
         start_block: 13885193
@@ -780,16 +789,9 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 130
-    rpc:
-      - for: "fallback"
-        url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 13885193
-  - contracts:
+  - id: 50
+    start_block: 85226452
+    contracts:
       - address: "0xe41909f5623c3b78219d9a2bb92be95aee5bbc30"
         name: "SablierMerkleFactory_v1_3"
         start_block: 85226452
@@ -808,9 +810,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 50
-    start_block: 85226452
-  - contracts:
+  - id: 324
+    start_block: 33148970
+    rpc:
+      - for: "fallback"
+        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x46de683d20c3575a0381ffd66c10ab6836390140"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 33148970
@@ -838,16 +847,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 324
+  - id: 84532
+    start_block: 7545874
     rpc:
       - for: "fallback"
-        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 33148970
-  - contracts:
+        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf632521bbab0dbc2bef169865e6c8e285afe0a42"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 7545874
@@ -875,16 +884,16 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 84532
+  - id: 11155111
+    start_block: 4904900
     rpc:
       - for: "fallback"
-        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 7545874
-  - contracts:
+        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xbacc1d151a78eed71d504f701c25e8739dc0262d"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 4904900
@@ -912,12 +921,3 @@ networks:
       - name: "SablierMerkleInstant_v2_0"
       - name: "SablierMerkleLL_v2_0"
       - name: "SablierMerkleLT_v2_0"
-    id: 11155111
-    rpc:
-      - for: "fallback"
-        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 4904900

--- a/envio/analytics/config.yaml
+++ b/envio/analytics/config.yaml
@@ -264,7 +264,16 @@ contracts:
       - event: "RenounceLockupStream"
       - event: "WithdrawFromLockupStream"
 networks:
-  - contracts:
+  - id: 1
+    start_block: 17613133
+    rpc:
+      - for: "fallback"
+        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x1a272b596b10f02931480bc7a3617db4a8d154e3"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 18811605
@@ -328,16 +337,16 @@ networks:
       - address: "0xcf8ce57fa442ba50acbc57147a62ad03873ffa73"
         name: "SablierLockup_v3_0"
         start_block: 23500619
-    id: 1
+  - id: 10
+    start_block: 106405061
     rpc:
       - for: "fallback"
-        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 17613133
-  - contracts:
+        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x044ec80fbec40f0ee7e7b3856828170971796c19"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 113621901
@@ -401,16 +410,9 @@ networks:
       - address: "0xe2620fb20fc9de61cd207d921691f4ee9d0fffd0"
         name: "SablierLockup_v3_0"
         start_block: 141962546
-    id: 10
-    rpc:
-      - for: "fallback"
-        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 106405061
-  - contracts:
+  - id: 50
+    start_block: 85225620
+    contracts:
       - address: "0xe41909f5623c3b78219d9a2bb92be95aee5bbc30"
         name: "SablierMerkleFactory_v1_3"
         start_block: 85226452
@@ -441,9 +443,16 @@ networks:
       - address: "0x2266901b1ecf499b4c91b6cbea8e06700cfbde1e"
         name: "SablierLockup_v3_0"
         start_block: 94381434
-    id: 50
-    start_block: 85225620
-  - contracts:
+  - id: 56
+    start_block: 29646271
+    rpc:
+      - for: "fallback"
+        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x434d73465aac4125d204a6637eb6c579d8d69f48"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 34438438
@@ -507,16 +516,14 @@ networks:
       - address: "0x06bd1ec1d80acc45ba332f79b08d2d9e24240c74"
         name: "SablierLockup_v3_0"
         start_block: 63357633
-    id: 56
+  - id: 100
+    start_block: 28766600
     rpc:
-      - for: "fallback"
-        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 29646271
-  - contracts:
+        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x777f66477ff83ababadf39a3f22a8cc3aee43765"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 31491795
@@ -580,14 +587,16 @@ networks:
       - address: "0x87f87eb0b59421d1b2df7301037e923932176681"
         name: "SablierLockup_v3_0"
         start_block: 42440688
-    id: 100
+  - id: 130
+    start_block: 13882080
     rpc:
+      - for: "fallback"
+        url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 28766600
-  - contracts:
+        url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xc6fc028e988d158c52aa2e38cdd6f969aa14bdcd"
         name: "SablierMerkleFactory_v1_3"
         start_block: 13885193
@@ -618,16 +627,16 @@ networks:
       - address: "0xffb540fc132dcefb0fdef96ef63fe2f2f1bd7cfd"
         name: "SablierLockup_v3_0"
         start_block: 28781988
-    id: 130
+  - id: 137
+    start_block: 44637127
     rpc:
       - for: "fallback"
-        url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 13882080
-  - contracts:
+        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf4906225e783fb8977410bdbfb960cabed6c2ef4"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 51245836
@@ -691,16 +700,14 @@ networks:
       - address: "0x1e901b0e05a78c011d6d4cffdbdb28a42a1c32ef"
         name: "SablierLockup_v3_0"
         start_block: 77222315
-    id: 137
+  - id: 143
+    start_block: 34582553
     rpc:
-      - for: "fallback"
-        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 44637127
-  - contracts:
+        url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xab15e653cd3bbce7b7412f81056a450bc0f2e7b9"
         name: "SablierFactoryMerkleInstant_v2_0"
         start_block: 34590049
@@ -719,14 +726,14 @@ networks:
       - address: "0x003f5393f4836f710d492ad98d89f5bfccf1c962"
         name: "SablierLockup_v3_0"
         start_block: 34585784
-    id: 143
+  - id: 146
+    start_block: 43943890
     rpc:
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 34582553
-  - contracts:
+        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xbd73389cbdd4f31f374f2815ecb7f9dec0f124d3"
         name: "SablierMerkleFactory_v1_3"
         start_block: 43945441
@@ -757,14 +764,16 @@ networks:
       - address: "0x763cfb7df1d1bfe50e35e295688b3df789d2febb"
         name: "SablierLockup_v3_0"
         start_block: 49254811
-    id: 146
+  - id: 324
+    start_block: 32472581
     rpc:
+      - for: "fallback"
+        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 43943890
-  - contracts:
+        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x46de683d20c3575a0381ffd66c10ab6836390140"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 33148970
@@ -822,16 +831,9 @@ networks:
       - address: "0xc07e338ce1aed183a8b3c55f980548f5e463b5c5"
         name: "SablierLockup_v3_0"
         start_block: 65048306
-    id: 324
-    rpc:
-      - for: "fallback"
-        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 32472581
-  - contracts:
+  - id: 999
+    start_block: 8594061
+    contracts:
       - address: "0xe0548364372f3b842e6f89e2dac2e53b5ea0a35b"
         name: "SablierMerkleFactory_v1_3"
         start_block: 8665370
@@ -862,9 +864,14 @@ networks:
       - address: "0x50ff828e66612a4d1f7141936f2b4078c7356329"
         name: "SablierLockup_v3_0"
         start_block: 15758852
-    id: 999
-    start_block: 8594061
-  - contracts:
+  - id: 2741
+    start_block: 72821
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xe2c0c3e0ff10df4485a2dcbbdd1d002a40446164"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 73620
@@ -912,14 +919,9 @@ networks:
       - address: "0x293d8d192c0c93225ff6bbe7415a56b57379bba3"
         name: "SablierLockup_v3_0"
         start_block: 20582992
-    id: 2741
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 72821
-  - contracts:
+  - id: 2818
+    start_block: 45825
+    contracts:
       - address: "0x5e73bb96493c10919204045fcdb639d35ad859f8"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 45862
@@ -967,9 +969,14 @@ networks:
       - address: "0xe646d9a037c6b62e4d417592a10f57e77f007a27"
         name: "SablierLockup_v3_0"
         start_block: 17491200
-    id: 2818
-    start_block: 45825
-  - contracts:
+  - id: 5330
+    start_block: 799582
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf60beadefbeb98c927e13c4165bca7d85ba32cb2"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 2896477
@@ -1017,14 +1024,16 @@ networks:
       - address: "0x2f1c6ad6306bd0200d55b59ad54d4b44067d00e6"
         name: "SablierLockup_v3_0"
         start_block: 16675054
-    id: 5330
+  - id: 8453
+    start_block: 1750275
     rpc:
+      - for: "fallback"
+        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 799582
-  - contracts:
+        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x5545c8e7c3e1f74adc98e518f2e8d23a002c4412"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 8026894
@@ -1088,16 +1097,9 @@ networks:
       - address: "0xe261b366f231b12fcb58d6bbd71e57faee82431d"
         name: "SablierLockup_v3_0"
         start_block: 36357687
-    id: 8453
-    rpc:
-      - for: "fallback"
-        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 1750275
-  - contracts:
+  - id: 34443
+    start_block: 11343389
+    contracts:
       - address: "0x0fd01dd30f96a15de6afad5627d45ef94752460a"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 11343396
@@ -1145,9 +1147,16 @@ networks:
       - address: "0x9513ce572d4f4aac1dd493bcd50866235d1c698d"
         name: "SablierLockup_v3_0"
         start_block: 29677617
-    id: 34443
-    start_block: 11343389
-  - contracts:
+  - id: 42161
+    start_block: 107508404
+    rpc:
+      - for: "fallback"
+        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x237400ef5a41886a75b0e036228221df075b3b80"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 161026555
@@ -1211,16 +1220,16 @@ networks:
       - address: "0xf12abfb041b5064b839ca56638cdb62fea712db5"
         name: "SablierLockup_v3_0"
         start_block: 385670671
-    id: 42161
+  - id: 43114
+    start_block: 32164219
     rpc:
       - for: "fallback"
-        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 107508404
-  - contracts:
+        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x4849e797d7aab20fcc8f807efafdfff98a83412e"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 41023959
@@ -1284,16 +1293,9 @@ networks:
       - address: "0x7e146250ed5cccc6ada924d456947556902acafd"
         name: "SablierLockup_v3_0"
         start_block: 69716263
-    id: 43114
-    rpc:
-      - for: "fallback"
-        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 32164219
-  - contracts:
+  - id: 50104
+    start_block: 11275708
+    contracts:
       - address: "0x9d4923e2ff0b9dadc447a89f528760928f84d0f7"
         name: "SablierMerkleFactory_v1_3"
         start_block: 11290094
@@ -1306,9 +1308,16 @@ networks:
       - address: "0x28fcae6bda2546c93183eec8638691b2eb184003"
         name: "SablierLockup_v2_0"
         start_block: 11275708
-    id: 50104
-    start_block: 11275708
-  - contracts:
+  - id: 59144
+    start_block: 7728316
+    rpc:
+      - for: "fallback"
+        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x35e9c3445a039b258eb7112a5eea259a825e8ac0"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 8688454
@@ -1356,16 +1365,14 @@ networks:
       - address: "0xc853db30a908dc1b655bbd4a8b9d5db8588c13c8"
         name: "SablierLockup_v3_0"
         start_block: 24117277
-    id: 59144
+  - id: 80094
+    start_block: 780094
     rpc:
-      - for: "fallback"
-        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 7728316
-  - contracts:
+        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x7868af143cc5e6cd03f9b4f5cdd2832695a85d6b"
         name: "SablierMerkleFactory_v1_3"
         start_block: 780306
@@ -1396,14 +1403,16 @@ networks:
       - address: "0xc37b51a3c3be55f0b34fbd8bd1f30cff6d251408"
         name: "SablierLockup_v3_0"
         start_block: 11304305
-    id: 80094
+  - id: 81457
+    start_block: 243844
     rpc:
+      - for: "fallback"
+        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 780094
-  - contracts:
+        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x92fc05e49c27884d554d98a5c01ff0894a9dc29a"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 244740
@@ -1461,16 +1470,11 @@ networks:
       - address: "0xcd16d89cc79ab0b52717a46b8a3f73e61014c7dc"
         name: "SablierLockup_v3_0"
         start_block: 25347901
-    id: 81457
-    rpc:
-      - for: "fallback"
-        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 243844
-  - contracts:
+  - id: 88888
+    start_block: 19125587
+    hypersync_config:
+      url: "https://chiliz.hypersync.xyz"
+    contracts:
       - address: "0x92fc05e49c27884d554d98a5c01ff0894a9dc29a"
         name: "SablierV2MerkleLockupFactory_v1_2"
         start_block: 19125620
@@ -1518,11 +1522,16 @@ networks:
       - address: "0x957a54ac691893b20c705e0b2eecbddf5220d019"
         name: "SablierLockup_v3_0"
         start_block: 27591344
-    hypersync_config:
-      url: "https://chiliz.hypersync.xyz"
-    id: 88888
-    start_block: 19125587
-  - contracts:
+  - id: 534352
+    start_block: 500707
+    rpc:
+      - for: "fallback"
+        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xb3ade5463000e6c0d376e7d7570f372ebf98bdaf"
         name: "SablierV2MerkleStreamerFactory_v1_1"
         start_block: 1675340
@@ -1586,12 +1595,3 @@ networks:
       - address: "0xcb60a39942cd5d1c2a1c8abbed99c43a73df3f8d"
         name: "SablierLockup_v3_0"
         start_block: 22483294
-    id: 534352
-    rpc:
-      - for: "fallback"
-        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 500707

--- a/envio/flow/config.yaml
+++ b/envio/flow/config.yaml
@@ -60,7 +60,14 @@ contracts:
       - event: "VoidFlowStream"
       - event: "WithdrawFromFlowStream"
 networks:
-  - contracts:
+  - id: 2741
+    start_block: 73630
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x001f1408515ccd5c1a19a682455ed4efa39dadd6"
         name: "SablierFlow_v1_0"
         start_block: 73630
@@ -70,14 +77,16 @@ networks:
       - address: "0xc415425e56cc6c42b87bacffb276db2292cc1e50"
         name: "SablierFlow_v2_0"
         start_block: 20608071
-    id: 2741
+  - id: 42161
+    start_block: 281305357
     rpc:
+      - for: "fallback"
+        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 73630
-  - contracts:
+        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x18a12a7035aa56240bcd236bc019aa245dcc015a"
         name: "SablierFlow_v1_0"
         start_block: 281305357
@@ -87,16 +96,16 @@ networks:
       - address: "0xf0f6477422a346378458f73cf02f05a7492e0c25"
         name: "SablierFlow_v2_0"
         start_block: 386120714
-    id: 42161
+  - id: 43114
+    start_block: 53922039
     rpc:
       - for: "fallback"
-        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 281305357
-  - contracts:
+        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x8c172e42c06302e3cfe555dc4d6b71a756ee186b"
         name: "SablierFlow_v1_0"
         start_block: 53922039
@@ -106,16 +115,16 @@ networks:
       - address: "0x64dc318ba879eca8222e963d319728f211c600c7"
         name: "SablierFlow_v2_0"
         start_block: 69776725
-    id: 43114
+  - id: 8453
+    start_block: 23269999
     rpc:
       - for: "fallback"
-        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 53922039
-  - contracts:
+        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x1a9adc0e2114c8407cc31669baafeee031d15dd2"
         name: "SablierFlow_v1_0"
         start_block: 23269999
@@ -125,16 +134,16 @@ networks:
       - address: "0x8551208f75375abfaee1fbe0a69e390a94000ec2"
         name: "SablierFlow_v2_0"
         start_block: 36413487
-    id: 8453
+  - id: 81457
+    start_block: 12259771
     rpc:
       - for: "fallback"
-        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 23269999
-  - contracts:
+        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xfdac2799644141856e20e021ac06f231cafc731f"
         name: "SablierFlow_v1_0"
         start_block: 12259771
@@ -144,30 +153,30 @@ networks:
       - address: "0x13ce2ca4602d5d1dd323014cd5a4e8414d310a06"
         name: "SablierFlow_v2_0"
         start_block: 25403293
-    id: 81457
+  - id: 80094
+    start_block: 780382
     rpc:
-      - for: "fallback"
-        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 12259771
-  - contracts:
+        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xa031544946ed769377128fbd961c9d621c4b4179"
         name: "SablierFlow_v1_1"
         start_block: 780382
       - address: "0xb89cc68b2ef376ca1b9645f109f7a490b180cf1b"
         name: "SablierFlow_v2_0"
         start_block: 11353858
-    id: 80094
+  - id: 56
+    start_block: 44582847
     rpc:
+      - for: "fallback"
+        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 780382
-  - contracts:
+        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xfce01f79247cf450062545e7155d7bd568551d0e"
         name: "SablierFlow_v1_0"
         start_block: 44582847
@@ -177,16 +186,11 @@ networks:
       - address: "0x5505c2397b0bebeee64919f21df84f83c008c51b"
         name: "SablierFlow_v2_0"
         start_block: 63552929
-    id: 56
-    rpc:
-      - for: "fallback"
-        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 44582847
-  - contracts:
+  - id: 88888
+    start_block: 19125673
+    hypersync_config:
+      url: "https://chiliz.hypersync.xyz"
+    contracts:
       - address: "0x9efc8663cab0e2d97ad17c9fbfc8392445517e94"
         name: "SablierFlow_v1_0"
         start_block: 19125673
@@ -196,11 +200,14 @@ networks:
       - address: "0x21797da50e180d24d6a68e8be6f8daca1c06f0ee"
         name: "SablierFlow_v2_0"
         start_block: 27623892
-    hypersync_config:
-      url: "https://chiliz.hypersync.xyz"
-    id: 88888
-    start_block: 19125673
-  - contracts:
+  - id: 100
+    start_block: 37356094
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x5515f774a4db42820802333ba575f68a6e85bd13"
         name: "SablierFlow_v1_0"
         start_block: 37356094
@@ -210,23 +217,25 @@ networks:
       - address: "0xcdd3eb5283e4a675f16ba83e9d8c28c871a550a2"
         name: "SablierFlow_v2_0"
         start_block: 42459081
-    id: 100
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 37356094
-  - contracts:
+  - id: 999
+    start_block: 8663784
+    contracts:
       - address: "0x556d859dfeb58ed3fa092b6526b09da6b74113e2"
         name: "SablierFlow_v1_1"
         start_block: 8663784
       - address: "0x70ce7795896c1e226c71360f9d77b743d8302182"
         name: "SablierFlow_v2_0"
         start_block: 15760743
-    id: 999
-    start_block: 8663784
-  - contracts:
+  - id: 59144
+    start_block: 12929891
+    rpc:
+      - for: "fallback"
+        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x949bfa08f1632432a2656a9db17ca34d54da8296"
         name: "SablierFlow_v1_0"
         start_block: 12929891
@@ -236,16 +245,16 @@ networks:
       - address: "0x977fdf70abed6b60eeccee85322bea4575b0b6ed"
         name: "SablierFlow_v2_0"
         start_block: 24174155
-    id: 59144
+  - id: 1
+    start_block: 21330577
     rpc:
       - for: "fallback"
-        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 12929891
-  - contracts:
+        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x2d9221a63e12aa796619cb381ec4a71b201281f5"
         name: "SablierFlow_v1_0"
         start_block: 21330577
@@ -255,16 +264,9 @@ networks:
       - address: "0x7a86d3e6894f9c5b5f25ffbdaae658cfc7569623"
         name: "SablierFlow_v2_0"
         start_block: 23507359
-    id: 1
-    rpc:
-      - for: "fallback"
-        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 21330577
-  - contracts:
+  - id: 34443
+    start_block: 16616938
+    contracts:
       - address: "0x75970dde488431fc4961494569def3269f20d6b3"
         name: "SablierFlow_v1_0"
         start_block: 16616938
@@ -274,20 +276,20 @@ networks:
       - address: "0xbed2f163cc0aa3278261ef1c3fa51b98db270829"
         name: "SablierFlow_v2_0"
         start_block: 29724479
-    id: 34443
-    start_block: 16616938
-  - contracts:
-      - address: "0x0340a829b6dc3adf7710a5baf1970914af4977f5"
-        name: "SablierFlow_v2_0"
-        start_block: 34582553
-    id: 143
+  - id: 143
+    start_block: 34582553
     rpc:
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
         url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 34582553
-  - contracts:
+    contracts:
+      - address: "0x0340a829b6dc3adf7710a5baf1970914af4977f5"
+        name: "SablierFlow_v2_0"
+        start_block: 34582553
+  - id: 2818
+    start_block: 980797
+    contracts:
       - address: "0xfe6972d0ae797fae343e5a58d0c7d8513937f092"
         name: "SablierFlow_v1_0"
         start_block: 980797
@@ -297,9 +299,16 @@ networks:
       - address: "0xbf407836021c993dfa27cb8232415d15faea709a"
         name: "SablierFlow_v2_0"
         start_block: 17522576
-    id: 2818
-    start_block: 980797
-  - contracts:
+  - id: 10
+    start_block: 128865315
+    rpc:
+      - for: "fallback"
+        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x906356e4e6410ea0a97dbc5b071cf394ab0dcd69"
         name: "SablierFlow_v1_0"
         start_block: 128865315
@@ -309,16 +318,16 @@ networks:
       - address: "0xd18491649440d6338532f260761cee64e79d7bb2"
         name: "SablierFlow_v2_0"
         start_block: 142008894
-    id: 10
+  - id: 137
+    start_block: 65079319
     rpc:
       - for: "fallback"
-        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 128865315
-  - contracts:
+        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xcf2d812d5aad4e6fec3b05850ff056b21159d496"
         name: "SablierFlow_v1_0"
         start_block: 65079319
@@ -328,30 +337,30 @@ networks:
       - address: "0x62b6d5a3ac0cc91ecebd019d1c70fe955d8c7426"
         name: "SablierFlow_v2_0"
         start_block: 77265843
-    id: 137
+  - id: 146
+    start_block: 43944753
     rpc:
-      - for: "fallback"
-        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 65079319
-  - contracts:
+        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x63815da47c97063cc24b28d0b6f59234f71d5c96"
         name: "SablierFlow_v1_1"
         start_block: 43944753
       - address: "0x3954146884425accb86a6476dad69ec3591838cd"
         name: "SablierFlow_v2_0"
         start_block: 49351959
-    id: 146
+  - id: 534352
+    start_block: 11643209
     rpc:
+      - for: "fallback"
+        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 43944753
-  - contracts:
+        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x66826f53bffeaab71adc7fe1a77e86f8268848d8"
         name: "SablierFlow_v1_0"
         start_block: 11643209
@@ -361,22 +370,20 @@ networks:
       - address: "0xc3e92b9714ed01b51fdc29bb88b17af5cddd2c22"
         name: "SablierFlow_v2_0"
         start_block: 22568050
-    id: 534352
-    rpc:
-      - for: "fallback"
-        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 11643209
-  - contracts:
+  - id: 50104
+    start_block: 11341394
+    contracts:
       - address: "0x20c9a3e27322fc2b21ced430d1b2e12d90804db6"
         name: "SablierFlow_v1_1"
         start_block: 11341394
-    id: 50104
-    start_block: 11341394
-  - contracts:
+  - id: 5330
+    start_block: 3610744
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x4f5f9b3fb57bba43aaf90e3f71d8f8f384e88e20"
         name: "SablierFlow_v1_0"
         start_block: 3610744
@@ -386,21 +393,8 @@ networks:
       - address: "0xe91bbae6c7d67b7c5055de1c9635c17af056211b"
         name: "SablierFlow_v2_0"
         start_block: 16718519
-    id: 5330
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 3610744
-  - contracts:
-      - address: "0x9797b40340be0bfc9ec0dbb8712627bcdd17e771"
-        name: "SablierFlow_v1_1"
-        start_block: 13883575
-      - address: "0x170ecc032c96aa976fa702e94fbc9fa5bb64ee7c"
-        name: "SablierFlow_v2_0"
-        start_block: 28868371
-    id: 130
+  - id: 130
+    start_block: 13883575
     rpc:
       - for: "fallback"
         url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
@@ -408,17 +402,32 @@ networks:
         initial_block_interval: 2000
         interval_ceiling: 2000
         url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 13883575
-  - contracts:
+    contracts:
+      - address: "0x9797b40340be0bfc9ec0dbb8712627bcdd17e771"
+        name: "SablierFlow_v1_1"
+        start_block: 13883575
+      - address: "0x170ecc032c96aa976fa702e94fbc9fa5bb64ee7c"
+        name: "SablierFlow_v2_0"
+        start_block: 28868371
+  - id: 50
+    start_block: 85226840
+    contracts:
       - address: "0xd6482334242862951da3e730f818c3f6e3f45a30"
         name: "SablierFlow_v1_1"
         start_block: 85226840
       - address: "0x3f00b8334ebe2a85875d1f8b50a43a12db67acad"
         name: "SablierFlow_v2_0"
         start_block: 94421891
-    id: 50
-    start_block: 85226840
-  - contracts:
+  - id: 324
+    start_block: 50572220
+    rpc:
+      - for: "fallback"
+        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x015899a075b7c181e357cd0ed000683dbb4f1fce"
         name: "SablierFlow_v1_0"
         start_block: 50572220
@@ -428,16 +437,16 @@ networks:
       - address: "0xa7f02e692973b6315eaca7fb4285ad2536a89cd0"
         name: "SablierFlow_v2_0"
         start_block: 65054681
-    id: 324
+  - id: 84532
+    start_block: 18780695
     rpc:
       - for: "fallback"
-        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 50572220
-  - contracts:
+        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xd5f78708d83ac2bc8734a8cdf2d112c1bb3b62a2"
         name: "SablierFlow_v1_0"
         start_block: 18780695
@@ -447,16 +456,16 @@ networks:
       - address: "0x19e99dcdbaf2fbf43c60cfd026d571860da29d43"
         name: "SablierFlow_v2_0"
         start_block: 31923790
-    id: 84532
+  - id: 11155111
+    start_block: 7210716
     rpc:
       - for: "fallback"
-        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 18780695
-  - contracts:
+        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x5ae8c13f6ae094887322012425b34b0919097d8a"
         name: "SablierFlow_v1_0"
         start_block: 7210716
@@ -466,12 +475,3 @@ networks:
       - address: "0xde489096ec9c718358c52a8bbe4ffd74857356e9"
         name: "SablierFlow_v2_0"
         start_block: 9343957
-    id: 11155111
-    rpc:
-      - for: "fallback"
-        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 7210716

--- a/envio/lockup/config.yaml
+++ b/envio/lockup/config.yaml
@@ -118,7 +118,14 @@ contracts:
       - event: "RenounceLockupStream"
       - event: "WithdrawFromLockupStream"
 networks:
-  - contracts:
+  - id: 2741
+    start_block: 72821
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xc69c06c030e825ede13f1486078aa9a2e2aaffaf"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 72821
@@ -134,14 +141,16 @@ networks:
       - address: "0x293d8d192c0c93225ff6bbe7415a56b57379bba3"
         name: "SablierLockup_v3_0"
         start_block: 20582992
-    id: 2741
+  - id: 42161
+    start_block: 107508404
     rpc:
+      - for: "fallback"
+        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://abstract-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 72821
-  - contracts:
+        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xa9efbef1a35ff80041f567391bdc9813b2d50197"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 107508404
@@ -169,16 +178,16 @@ networks:
       - address: "0xf12abfb041b5064b839ca56638cdb62fea712db5"
         name: "SablierLockup_v3_0"
         start_block: 385670671
-    id: 42161
+  - id: 43114
+    start_block: 32164219
     rpc:
       - for: "fallback"
-        url: "https://arbitrum-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://arb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 107508404
-  - contracts:
+        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x665d1c8337f1035cfbe13dd94bb669110b975f5f"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 32164219
@@ -206,16 +215,16 @@ networks:
       - address: "0x7e146250ed5cccc6ada924d456947556902acafd"
         name: "SablierLockup_v3_0"
         start_block: 69716263
-    id: 43114
+  - id: 8453
+    start_block: 1750275
     rpc:
       - for: "fallback"
-        url: "https://avalanche-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://avax-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 32164219
-  - contracts:
+        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x645b00960dc352e699f89a81fc845c0c645231cf"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 1750275
@@ -243,16 +252,16 @@ networks:
       - address: "0xe261b366f231b12fcb58d6bbd71e57faee82431d"
         name: "SablierLockup_v3_0"
         start_block: 36357687
-    id: 8453
+  - id: 81457
+    start_block: 243844
     rpc:
       - for: "fallback"
-        url: "https://base-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 1750275
-  - contracts:
+        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xdf578c2c70a86945999c65961417057363530a1c"
         name: "SablierV2LockupDynamic_v1_1"
         start_block: 243844
@@ -274,30 +283,30 @@ networks:
       - address: "0xcd16d89cc79ab0b52717a46b8a3f73e61014c7dc"
         name: "SablierLockup_v3_0"
         start_block: 25347901
-    id: 81457
+  - id: 80094
+    start_block: 780094
     rpc:
-      - for: "fallback"
-        url: "https://blast-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://blast-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 243844
-  - contracts:
+        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xc19a2542156b5d7960e0ef46e9787e7d336cf428"
         name: "SablierLockup_v2_0"
         start_block: 780094
       - address: "0xc37b51a3c3be55f0b34fbd8bd1f30cff6d251408"
         name: "SablierLockup_v3_0"
         start_block: 11304305
-    id: 80094
+  - id: 56
+    start_block: 29646271
     rpc:
+      - for: "fallback"
+        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://berachain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 780094
-  - contracts:
+        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf2f3fef2454dca59eca929d2d8cd2a8669cc6214"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 29646271
@@ -325,16 +334,11 @@ networks:
       - address: "0x06bd1ec1d80acc45ba332f79b08d2d9e24240c74"
         name: "SablierLockup_v3_0"
         start_block: 63357633
-    id: 56
-    rpc:
-      - for: "fallback"
-        url: "https://bsc-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://bnb-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 29646271
-  - contracts:
+  - id: 88888
+    start_block: 19125587
+    hypersync_config:
+      url: "https://chiliz.hypersync.xyz"
+    contracts:
       - address: "0xcff4a803b0bf55dd1be38fb96088478f3d2eecf2"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 19125587
@@ -350,11 +354,14 @@ networks:
       - address: "0x957a54ac691893b20c705e0b2eecbddf5220d019"
         name: "SablierLockup_v3_0"
         start_block: 27591344
-    hypersync_config:
-      url: "https://chiliz.hypersync.xyz"
-    id: 88888
-    start_block: 19125587
-  - contracts:
+  - id: 100
+    start_block: 28766600
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xeb148e4ec13aaa65328c0ba089a278138e9e53f9"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 28766600
@@ -382,23 +389,25 @@ networks:
       - address: "0x87f87eb0b59421d1b2df7301037e923932176681"
         name: "SablierLockup_v3_0"
         start_block: 42440688
-    id: 100
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://gnosis-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 28766600
-  - contracts:
+  - id: 999
+    start_block: 8594061
+    contracts:
       - address: "0x856167ee3e09ba562d69a542ab6a939903ad738e"
         name: "SablierLockup_v2_0"
         start_block: 8594061
       - address: "0x50ff828e66612a4d1f7141936f2b4078c7356329"
         name: "SablierLockup_v3_0"
         start_block: 15758852
-    id: 999
-    start_block: 8594061
-  - contracts:
+  - id: 59144
+    start_block: 7728316
+    rpc:
+      - for: "fallback"
+        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf2e46b249cfe09c2b3a2022dc81e0bb4be3336f1"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 7728316
@@ -414,16 +423,16 @@ networks:
       - address: "0xc853db30a908dc1b655bbd4a8b9d5db8588c13c8"
         name: "SablierLockup_v3_0"
         start_block: 24117277
-    id: 59144
+  - id: 1
+    start_block: 17613133
     rpc:
       - for: "fallback"
-        url: "https://linea-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://linea-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 7728316
-  - contracts:
+        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x39efdc3dbb57b2388ccc4bb40ac4cb1226bc9e44"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 17613133
@@ -451,16 +460,9 @@ networks:
       - address: "0xcf8ce57fa442ba50acbc57147a62ad03873ffa73"
         name: "SablierLockup_v3_0"
         start_block: 23500619
-    id: 1
-    rpc:
-      - for: "fallback"
-        url: "https://mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 17613133
-  - contracts:
+  - id: 34443
+    start_block: 11343389
+    contracts:
       - address: "0x704552099f5ad679294d337638b9a57fd4726f52"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 11343389
@@ -476,20 +478,20 @@ networks:
       - address: "0x9513ce572d4f4aac1dd493bcd50866235d1c698d"
         name: "SablierLockup_v3_0"
         start_block: 29677617
-    id: 34443
-    start_block: 11343389
-  - contracts:
-      - address: "0x003f5393f4836f710d492ad98d89f5bfccf1c962"
-        name: "SablierLockup_v3_0"
-        start_block: 34585784
-    id: 143
+  - id: 143
+    start_block: 34585784
     rpc:
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
         url: "https://monad-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 34585784
-  - contracts:
+    contracts:
+      - address: "0x003f5393f4836f710d492ad98d89f5bfccf1c962"
+        name: "SablierLockup_v3_0"
+        start_block: 34585784
+  - id: 2818
+    start_block: 45825
+    contracts:
       - address: "0x946654ab30dd6ed10236c89f2c8b2719df653691"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 45825
@@ -505,9 +507,16 @@ networks:
       - address: "0xe646d9a037c6b62e4d417592a10f57e77f007a27"
         name: "SablierLockup_v3_0"
         start_block: 17491200
-    id: 2818
-    start_block: 45825
-  - contracts:
+  - id: 10
+    start_block: 106405061
+    rpc:
+      - for: "fallback"
+        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x6f68516c21e248cddfaf4898e66b2b0adee0e0d6"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 106405061
@@ -535,16 +544,16 @@ networks:
       - address: "0xe2620fb20fc9de61cd207d921691f4ee9d0fffd0"
         name: "SablierLockup_v3_0"
         start_block: 141962546
-    id: 10
+  - id: 137
+    start_block: 44637127
     rpc:
       - for: "fallback"
-        url: "https://optimism-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://opt-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 106405061
-  - contracts:
+        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x7313addb53f96a4f710d3b91645c62b434190725"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 44637127
@@ -572,30 +581,30 @@ networks:
       - address: "0x1e901b0e05a78c011d6d4cffdbdb28a42a1c32ef"
         name: "SablierLockup_v3_0"
         start_block: 77222315
-    id: 137
+  - id: 146
+    start_block: 43943890
     rpc:
-      - for: "fallback"
-        url: "https://polygon-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://polygon-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 44637127
-  - contracts:
+        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xc37462ee6500d2c36c9131b921faadbd6cb7b60b"
         name: "SablierLockup_v2_0"
         start_block: 43943890
       - address: "0x763cfb7df1d1bfe50e35e295688b3df789d2febb"
         name: "SablierLockup_v3_0"
         start_block: 49254811
-    id: 146
+  - id: 534352
+    start_block: 500707
     rpc:
+      - for: "fallback"
+        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://sonic-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 43943890
-  - contracts:
+        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xde6a30d851efd0fc2a9c922f294801cfd5fcb3a1"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 500707
@@ -623,22 +632,20 @@ networks:
       - address: "0xcb60a39942cd5d1c2a1c8abbed99c43a73df3f8d"
         name: "SablierLockup_v3_0"
         start_block: 22483294
-    id: 534352
-    rpc:
-      - for: "fallback"
-        url: "https://scroll-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://scroll-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 500707
-  - contracts:
+  - id: 50104
+    start_block: 11275708
+    contracts:
       - address: "0x28fcae6bda2546c93183eec8638691b2eb184003"
         name: "SablierLockup_v2_0"
         start_block: 11275708
-    id: 50104
-    start_block: 11275708
-  - contracts:
+  - id: 5330
+    start_block: 2896160
+    rpc:
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x1fa500262b352d821b4e1c933a20f2242b45383d"
         name: "SablierV2LockupDynamic_v1_2"
         start_block: 2896160
@@ -654,21 +661,8 @@ networks:
       - address: "0x2f1c6ad6306bd0200d55b59ad54d4b44067d00e6"
         name: "SablierLockup_v3_0"
         start_block: 16675054
-    id: 5330
-    rpc:
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://superseed-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 2896160
-  - contracts:
-      - address: "0x26c341c4d79ba8f6bfb450a49e9165c936316b14"
-        name: "SablierLockup_v2_0"
-        start_block: 13882080
-      - address: "0xffb540fc132dcefb0fdef96ef63fe2f2f1bd7cfd"
-        name: "SablierLockup_v3_0"
-        start_block: 28781988
-    id: 130
+  - id: 130
+    start_block: 13882080
     rpc:
       - for: "fallback"
         url: "https://unichain-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
@@ -676,17 +670,32 @@ networks:
         initial_block_interval: 2000
         interval_ceiling: 2000
         url: "https://unichain-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 13882080
-  - contracts:
+    contracts:
+      - address: "0x26c341c4d79ba8f6bfb450a49e9165c936316b14"
+        name: "SablierLockup_v2_0"
+        start_block: 13882080
+      - address: "0xffb540fc132dcefb0fdef96ef63fe2f2f1bd7cfd"
+        name: "SablierLockup_v3_0"
+        start_block: 28781988
+  - id: 50
+    start_block: 85225620
+    contracts:
       - address: "0x489e0dc5e62a751a2b209f1cc03e189fd6257176"
         name: "SablierLockup_v2_0"
         start_block: 85225620
       - address: "0x2266901b1ecf499b4c91b6cbea8e06700cfbde1e"
         name: "SablierLockup_v3_0"
         start_block: 94381434
-    id: 50
-    start_block: 85225620
-  - contracts:
+  - id: 324
+    start_block: 32472581
+    rpc:
+      - for: "fallback"
+        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+      - for: "fallback"
+        initial_block_interval: 2000
+        interval_ceiling: 2000
+        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xe6c7324bea8474209103e407779eec600c07cf3f"
         name: "SablierV2LockupDynamic_v1_1"
         start_block: 32472581
@@ -708,16 +717,16 @@ networks:
       - address: "0xc07e338ce1aed183a8b3c55f980548f5e463b5c5"
         name: "SablierLockup_v3_0"
         start_block: 65048306
-    id: 324
+  - id: 84532
+    start_block: 7545175
     rpc:
       - for: "fallback"
-        url: "https://zksync-mainnet.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://zksync-mainnet.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 32472581
-  - contracts:
+        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0xf46d5fa9bfc964e8d06846c8739aec69bc06344d"
         name: "SablierV2LockupDynamic_v1_1"
         start_block: 7545175
@@ -739,16 +748,16 @@ networks:
       - address: "0x5c51ea827bfa65f7c9af699e19ec9fb12a2d40e2"
         name: "SablierLockup_v3_0"
         start_block: 31869450
-    id: 84532
+  - id: 11155111
+    start_block: 4067889
     rpc:
       - for: "fallback"
-        url: "https://base-sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
+        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
       - for: "fallback"
         initial_block_interval: 2000
         interval_ceiling: 2000
-        url: "https://base-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 7545175
-  - contracts:
+        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
+    contracts:
       - address: "0x421e1e7a53ff360f70a2d02037ee394fa474e035"
         name: "SablierV2LockupDynamic_v1_0"
         start_block: 4067889
@@ -776,12 +785,3 @@ networks:
       - address: "0x6b0307b4338f2963a62106028e3b074c2c0510da"
         name: "SablierLockup_v3_0"
         start_block: 9336998
-    id: 11155111
-    rpc:
-      - for: "fallback"
-        url: "https://sepolia.infura.io/v3/${ENVIO_INFURA_API_KEY}"
-      - for: "fallback"
-        initial_block_interval: 2000
-        interval_ceiling: 2000
-        url: "https://eth-sepolia.g.alchemy.com/v2/${ENVIO_ALCHEMY_API_KEY}"
-    start_block: 4067889


### PR DESCRIPTION
Standardizes field ordering across all network configurations (id, start_block, rpc/hypersync_config, contracts) for improved readability. Updates code generation to match new field order.

fyi @gavriliumircea @razgraf this is a harmless change because it only reorders the fields in the YAML file to make them more readable.