### PR TITLE
fix: de-duplicate isToday date checking logic

### DIFF
--- a/envio/analytics/effects/coingecko.ts
+++ b/envio/analytics/effects/coingecko.ts
@@ -2,7 +2,6 @@ import axios from "axios";
 import axiosRetry from "axios-retry";
 import type { Logger } from "envio";
 import { experimental_createEffect, S } from "envio";
-import _ from "lodash";
 import {
   avalanche,
   berachain,
@@ -17,6 +16,7 @@ import {
   xdc,
 } from "sablier/evm/chains";
 import { COINGECKO_BASE_URL } from "../../common/constants";
+import { isToday } from "../../common/time";
 
 const MAX_RETRIES = 5;
 const NO_PRICE = 0;
@@ -107,19 +107,6 @@ type CurrentPriceResponse = {
     usd: number;
   };
 };
-
-/**
- * Check if a date string (DD-MM-YYYY format) is today in UTC
- */
-function isToday(dateString: string): boolean {
-  const today = new Date();
-  const [day, month, year] = dateString.split("-");
-  return (
-    today.getUTCDate() === _.toInteger(day) &&
-    today.getUTCMonth() + 1 === _.toInteger(month) &&
-    today.getUTCFullYear() === _.toInteger(year)
-  );
-}
 
 function getApiKey(): string {
   const apiKey = process.env.ENVIO_COINGECKO_API_KEY;

--- a/envio/analytics/effects/forex.ts
+++ b/envio/analytics/effects/forex.ts
@@ -1,12 +1,9 @@
 import axios from "axios";
-import dayjs from "dayjs";
-import utc from "dayjs/plugin/utc";
 import type { Logger } from "envio";
 import { experimental_createEffect, S } from "envio";
 import _ from "lodash";
 import { CURRENCY_FREAKS_BASE_URL } from "../../common/constants";
-
-dayjs.extend(utc);
+import { isToday } from "../../common/time";
 
 type CurrencyFreaksResponse = {
   rate: number;
@@ -113,8 +110,4 @@ function handleCurrencyFreaksError(logger: Logger, error: unknown, url: URL): vo
       url: url.toString(),
     });
   }
-}
-
-function isToday(date: string): boolean {
-  return dayjs(date).isSame(dayjs().utc(), "day");
 }

--- a/envio/common/time.ts
+++ b/envio/common/time.ts
@@ -46,6 +46,13 @@ export function getMonth(timestampInSeconds: number): string {
 }
 
 /**
+ * Check if a date string (YYYY-MM-DD format) is today in UTC.
+ */
+export function isToday(date: string): boolean {
+  return dayjs(date).isSame(dayjs().utc(), "day");
+}
+
+/**
  * This function converts a Unix timestamp to the first day of that month at 00:00:00.
  * @param timestampInSeconds - The Unix timestamp to convert, in seconds.
  * @returns The Date object representing the first day of the month at 00:00:00.


### PR DESCRIPTION
## Summary
- Consolidated duplicate `isToday` implementations from `coingecko.ts` and `forex.ts` into shared utility in `common/time.ts`
- Fixed bug where `coingecko.ts` incorrectly parsed dates as DD-MM-YYYY instead of YYYY-MM-DD
- Removed unused lodash and dayjs imports

## Changes
- `common/time.ts`: Added shared `isToday` function using dayjs
- `coingecko.ts`: Removed buggy local implementation and incorrect JSDoc
- `forex.ts`: Removed duplicate implementation and dayjs setup

Closes #262