### PR TITLE
refactor: convert Store namespace exports to object exports

### DIFF
--- a/envio/airdrops/store/index.ts
+++ b/envio/airdrops/store/index.ts
@@ -4,10 +4,10 @@ import * as EntityCampaign from "./entity-campaign";
 import * as EntityFactory from "./entity-factory";
 import * as EntityWatcher from "./entity-watcher";
 
-export namespace Store {
-  export import Action = EntityAction;
-  export import Activity = EntityActivity;
-  export import Campaign = EntityCampaign;
-  export import Factory = EntityFactory;
-  export import Watcher = EntityWatcher;
-}
+export const Store = {
+  Action: EntityAction,
+  Activity: EntityActivity,
+  Campaign: EntityCampaign,
+  Factory: EntityFactory,
+  Watcher: EntityWatcher,
+};

--- a/envio/common/store/index.ts
+++ b/envio/common/store/index.ts
@@ -4,12 +4,12 @@ import * as EntityContract from "./entity-contract";
 import * as EntityDeprecatedStream from "./entity-deprecated-stream";
 import * as EntityWatcher from "./entity-watcher";
 
-export namespace CommonStore {
-  export import Action = EntityAction;
-  export import Asset = EntityAsset;
-  export import Contract = EntityContract;
-  export import DeprecatedStream = EntityDeprecatedStream;
-  export import Watcher = EntityWatcher;
-}
+export const CommonStore = {
+  Action: EntityAction,
+  Asset: EntityAsset,
+  Contract: EntityContract,
+  DeprecatedStream: EntityDeprecatedStream,
+  Watcher: EntityWatcher,
+};
 
 export * as Contract from "./entity-contract";

--- a/envio/flow/store/index.ts
+++ b/envio/flow/store/index.ts
@@ -2,8 +2,8 @@ import * as EntityBatch from "./entity-batch";
 import * as EntityBatcher from "./entity-batcher";
 import * as EntityStream from "./entity-stream";
 
-export namespace Store {
-  export import Batch = EntityBatch;
-  export import Batcher = EntityBatcher;
-  export import Stream = EntityStream;
-}
+export const Store = {
+  Batch: EntityBatch,
+  Batcher: EntityBatcher,
+  Stream: EntityStream,
+};

--- a/envio/lockup/store/index.ts
+++ b/envio/lockup/store/index.ts
@@ -2,8 +2,8 @@ import * as EntityBatch from "./entity-batch";
 import * as EntityBatcher from "./entity-batcher";
 import * as EntityStream from "./entity-stream";
 
-export namespace Store {
-  export import Batch = EntityBatch;
-  export import Batcher = EntityBatcher;
-  export import Stream = EntityStream;
-}
+export const Store = {
+  Batch: EntityBatch,
+  Batcher: EntityBatcher,
+  Stream: EntityStream,
+};


### PR DESCRIPTION
Replace namespace pattern with plain object exports to enable proper type inference for Biome's noFloatingPromises lint rule.

Before: `export namespace Store { export import Entity = ... }`
After: `export const Store = { Entity: ... }`

This fixes a linting blind spot where async Store method calls without await were not being detected, preventing bugs like the one in `envio/airdrops/mappings/common/campaign/transfer-admin.ts:37`

this fixes #252 