### PR TITLE
feat: revive-graph

### DIFF
--- a/.github/workflows/cron-revive-graphs.yml
+++ b/.github/workflows/cron-revive-graphs.yml
@@ -1,3 +1,6 @@
+# The Graph deprecates subgraphs if no queries are made for 30 days.
+# This workflow pings the Graph endpoints to wake up dormant subgraphs.
+# We need it because Envio is the primary indexer in the UI.
 name: Graph Revive
 
 on:
@@ -11,16 +14,12 @@ jobs:
       GRAPH_QUERY_KEY: ${{ secrets.GRAPH_QUERY_KEY }}
     runs-on: ubuntu-latest
     steps:
-      - name: Check out the repo
-        uses: actions/checkout@v5
-
-      - name: Set up devkit
-        uses: sablier-labs/devkit/actions/setup@main
+      - uses: actions/checkout@v5
+      - uses: sablier-labs/devkit/actions/setup@v1
 
       - name: Ping Graph endpoints
-        id: revive
         continue-on-error: true
-        run: just graph-revive
+        run: just revive-graphs
 
       - name: Add summary
         if: always()

--- a/cli/commands/revive-graphs.ts
+++ b/cli/commands/revive-graphs.ts
@@ -2,9 +2,9 @@
  * @file Ping all The Graph endpoints to wake up dormant subgraphs
  *
  * @example
- * pnpm tsx cli graph-revive
- * pnpm tsx cli graph-revive --dry-run
- * pnpm tsx cli graph-revive --chain 1
+ * pnpm tsx cli revive-graphs
+ * pnpm tsx cli revive-graphs --dry-run
+ * pnpm tsx cli revive-graphs --chain 1
  */
 
 import { Command, Options } from "@effect/cli";
@@ -13,10 +13,10 @@ import { Console, Effect, Option } from "effect";
 import { GraphQLClient, gql } from "graphql-request";
 import { sablier } from "sablier";
 import { Protocol } from "sablier/evm";
-import { graphChains } from "../../../src/indexers/graph.js";
-import { getIndexerGraph } from "../../../src/indexers/index.js";
-import type { Indexer } from "../../../src/types.js";
-import { colors, createTable, displayHeader } from "../../display.js";
+import { graphChains } from "../../src/indexers/graph.js";
+import { getIndexerGraph } from "../../src/indexers/index.js";
+import type { Indexer } from "../../src/types.js";
+import { colors, createTable, displayHeader } from "../display.js";
 
 /* -------------------------------------------------------------------------- */
 /*                                   TYPES                                    */
@@ -332,7 +332,7 @@ const graphReviveLogic = (options: {
 /* -------------------------------------------------------------------------- */
 
 export const graphReviveCommand = Command.make(
-  "graph-revive",
+  "revive-graphs",
   {
     chain: chainOption,
     dryRun: dryRunOption,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -18,7 +18,6 @@ import { schemaCommand } from "./commands/codegen/schema.js";
 import { exportSchemaCommand } from "./commands/export-schema.js";
 import { graphDeployAllCommand } from "./commands/graph-deploy/all.js";
 import { graphDeployCustomCommand } from "./commands/graph-deploy/custom.js";
-import { graphReviveCommand } from "./commands/graph-revive/index.js";
 import { pricesCheckCommand } from "./commands/prices/check.js";
 import { pricesSyncCommand } from "./commands/prices/sync.js";
 import { printChainsCommand } from "./commands/print-chains.js";
@@ -26,6 +25,7 @@ import { queryActionsCommand } from "./commands/query/actions.js";
 import { queryAverageMauCommand } from "./commands/query/average-mau.js";
 import { queryTotalUsdFeesCommand } from "./commands/query/total-usd-fees.js";
 import { queryUniqueTxsCommand } from "./commands/query/unique-txs.js";
+import { graphReviveCommand } from "./commands/revive-graphs.js";
 import { CliLive } from "./context.js";
 
 /* -------------------------------------------------------------------------- */

--- a/recipes/graph.just
+++ b/recipes/graph.just
@@ -49,8 +49,8 @@ _codegen-graph-bindings indexer:
 
 # Ping all Graph endpoints to wake up dormant subgraphs
 [group("graph")]
-@graph-revive *args:
-    just cli graph-revive {{ args }}
+@revive-graphs *args:
+    just cli revive-graphs {{ args }}
 
 # ---------------------------------------------------------------------------- #
 #                                 PRIVATE UTILS                                #


### PR DESCRIPTION
Fixes #295. It implements a CLI command that pings all protocol endpoints on all chains with a simple query and logs some basic information like request time and status. 

Since this will be useful to "revive" endpoints from being marked as inactive, the command is also linked to a github action that runs once per week.

<img width="1613" height="878" alt="Screenshot 2026-01-29 at 17 25 34" src="https://github.com/user-attachments/assets/af6a739b-cd9e-438c-9bcc-7b8299f5e555" />
