### PR TITLE
feat: add support for airdrop sponsorships

### DIFF
--- a/envio/airdrops/airdrops.graphql
+++ b/envio/airdrops/airdrops.graphql
@@ -460,3 +460,95 @@ type Tranche @entity(immutable: true) {
   """
   startPercentage: BigInt!
 }
+
+"""
+An address that has sponsored a Sablier airdrop campaign via the Sponsor event.
+"""
+type Sponsor @entity(immutable: false) {
+  """
+  Unique identifier: `{chainId}_{address}`
+  """
+  id: String!
+  """
+  Address of the sponsor.
+  """
+  address: String!
+  """
+  The chain ID where the sponsorship was made (sponsorships are chain-specific).
+  """
+  chainId: Int!
+  """
+  Number of sponsorships made by this sponsor.
+  """
+  sponsorshipCount: Int!
+  """
+  List of individual sponsorship events by this sponsor.
+  """
+  sponsorships: [Sponsorship!]! @derivedFrom(field: "sponsor")
+  """
+  Cumulative raw USDC amount paid by the sponsor.
+  """
+  totalAmount: BigInt!
+  """
+  Human-readable cumulative USDC amount paid by the sponsor (e.g., "1729.12").
+  """
+  totalAmountDisplay: String!
+}
+
+"""
+A single Sponsor event on a campaign contract. Immutable — one per Sponsor event.
+"""
+type Sponsorship @entity(immutable: true) {
+  """
+  Unique identifier: `{chainId}_{txHash}_{logIndex}`
+  """
+  id: String!
+  """
+  Raw USDC amount.
+  """
+  amount: BigInt!
+  """
+  Human-readable USDC amount (e.g., "1719.12").
+  """
+  amountDisplay: String!
+  """
+  Block number of the transaction.
+  """
+  block: Int!
+  """
+  Address of the campaign contract that emitted the Sponsor event.
+  """
+  campaignAddress: String!
+  """
+  ID of the campaign entity (format: `{address}-{chainId}`).
+  """
+  campaignId: String!
+  """
+  The ID of the chain where the sponsorship occurred.
+  """
+  chainId: Int!
+  """
+  Log index of the Sponsor event within the block.
+  """
+  logIndex: Int!
+  """
+  Address of the caller who initiated the sponsor transaction.
+  """
+  sender: String!
+  """
+  The sponsor who made this payment.
+  """
+  sponsor: Sponsor!
+  """
+  Unix timestamp of the transaction.
+  """
+  timestamp: Int!
+  """
+  Address of the USDC token used for payment.
+  """
+  token: String!
+  """
+  Hash of the transaction.
+  """
+  txHash: String!
+}

--- a/envio/airdrops/bindings.ts
+++ b/envio/airdrops/bindings.ts
@@ -76,6 +76,8 @@ import type {
   Asset as EntityAsset,
   Campaign as EntityCampaign,
   Factory as EntityFactory,
+  Sponsor as EntitySponsor,
+  Sponsorship as EntitySponsorship,
   Tranche as EntityTranche,
   Watcher as EntityWatcher,
 } from "./bindings/src/Types.gen";
@@ -86,6 +88,8 @@ export namespace Entity {
   export type Asset = EntityAsset;
   export type Campaign = EntityCampaign;
   export type Factory = EntityFactory;
+  export type Sponsor = EntitySponsor;
+  export type Sponsorship = EntitySponsorship;
   export type Tranche = EntityTranche;
   export type Watcher = EntityWatcher;
 }

--- a/envio/airdrops/config.yaml
+++ b/envio/airdrops/config.yaml
@@ -143,6 +143,7 @@ contracts:
       - event: "Clawback"
       - event: "ClaimInstant"
       - event: "LowerMinFeeUSD"
+      - event: "Sponsor"
   - name: "SablierMerkleLL_v3_0"
     handler: "mappings/v3.0/SablierMerkleLL.ts"
     abi_file_path: "../../node_modules/sablier/abi/airdrops/v3.0/SablierMerkleLL.json"
@@ -152,6 +153,7 @@ contracts:
       - event: "ClaimLLWithTransfer"
       - event: "ClaimLLWithVesting"
       - event: "LowerMinFeeUSD"
+      - event: "Sponsor"
   - name: "SablierMerkleLT_v3_0"
     handler: "mappings/v3.0/SablierMerkleLT.ts"
     abi_file_path: "../../node_modules/sablier/abi/airdrops/v3.0/SablierMerkleLT.json"
@@ -161,6 +163,7 @@ contracts:
       - event: "ClaimLTWithTransfer"
       - event: "ClaimLTWithVesting"
       - event: "LowerMinFeeUSD"
+      - event: "Sponsor"
   - name: "SablierMerkleVCA_v3_0"
     handler: "mappings/v3.0/SablierMerkleVCA.ts"
     abi_file_path: "../../node_modules/sablier/abi/airdrops/v3.0/SablierMerkleVCA.json"
@@ -169,6 +172,7 @@ contracts:
       - event: "Clawback"
       - event: "ClaimVCA"
       - event: "LowerMinFeeUSD"
+      - event: "Sponsor"
       - event: "EnableRedistribution"
 networks:
   - id: 2741

--- a/envio/airdrops/justfile
+++ b/envio/airdrops/justfile
@@ -1,7 +1,7 @@
 import "../envio.just"
 
 # Run `just --evaluate ENVIO_HASURA_PUBLIC_AGGREGATE` to see the result
-export ENVIO_HASURA_PUBLIC_AGGREGATE := "Action&Activity&Asset&Campaign"
+export ENVIO_HASURA_PUBLIC_AGGREGATE := "Action&Activity&Asset&Campaign&Sponsor&Sponsorship"
 export ENVIO_INDEXER_NAME := "airdrops"
 export INDEXER_NAME := "airdrops"
 

--- a/envio/airdrops/mappings/common/campaign/index.ts
+++ b/envio/airdrops/mappings/common/campaign/index.ts
@@ -3,4 +3,5 @@ export * from "./claim-lockup";
 export * from "./claim-vca";
 export * from "./clawback";
 export * from "./lower-min-fee-usd";
+export * from "./sponsorship";
 export * from "./transfer-admin";

--- a/envio/airdrops/mappings/common/campaign/sponsorship.ts
+++ b/envio/airdrops/mappings/common/campaign/sponsorship.ts
@@ -1,0 +1,109 @@
+import { formatUnits } from "viem";
+import { Id } from "../../../../common/id";
+import { usdc } from "../../../../common/usdc";
+import type {
+  SablierMerkleInstant_v3_0_Sponsor_handler,
+  SablierMerkleLL_v3_0_Sponsor_handler,
+  SablierMerkleLT_v3_0_Sponsor_handler,
+  SablierMerkleVCA_v3_0_Sponsor_handler,
+} from "../../../bindings/src/Types.gen";
+
+/* -------------------------------------------------------------------------- */
+/*                                   HANDLER                                  */
+/* -------------------------------------------------------------------------- */
+
+type Handler = SablierMerkleInstant_v3_0_Sponsor_handler &
+  SablierMerkleLL_v3_0_Sponsor_handler &
+  SablierMerkleLT_v3_0_Sponsor_handler &
+  SablierMerkleVCA_v3_0_Sponsor_handler;
+
+const handler: Handler = async ({ context, event }) => {
+  /* -------------------------------- VALIDATE -------------------------------- */
+  const usdcInfo = usdc[event.chainId];
+  if (!usdcInfo) {
+    return;
+  }
+  if (event.params.token.toLowerCase() !== usdcInfo.address.toLowerCase()) {
+    return;
+  }
+  if (event.params.amount === 0n) {
+    return;
+  }
+
+  const decimals = usdcInfo.decimals;
+
+  /* -------------------------------- SPONSOR --------------------------------- */
+  const sponsor = await getOrCreateSponsor(context, event, decimals);
+
+  /* ------------------------------ SPONSORSHIP ------------------------------- */
+  createSponsorship(context, event, sponsor.id, decimals);
+};
+
+/* -------------------------------------------------------------------------- */
+/*                                   HELPERS                                  */
+/* -------------------------------------------------------------------------- */
+
+async function getOrCreateSponsor(
+  context: Parameters<Handler>[0]["context"],
+  event: Parameters<Handler>[0]["event"],
+  decimals: number
+) {
+  const address = event.params.biller.toLowerCase();
+  const id = `${event.chainId}_${address}`;
+  const sponsor = await context.Sponsor.get(id);
+
+  if (sponsor) {
+    const totalAmount = sponsor.totalAmount + event.params.amount;
+    const updated = {
+      ...sponsor,
+      sponsorshipCount: sponsor.sponsorshipCount + 1,
+      totalAmount,
+      totalAmountDisplay: formatUnits(totalAmount, decimals),
+    };
+    context.Sponsor.set(updated);
+    return updated;
+  }
+
+  const newSponsor = {
+    address,
+    chainId: event.chainId,
+    id,
+    sponsorshipCount: 1,
+    totalAmount: event.params.amount,
+    totalAmountDisplay: formatUnits(event.params.amount, decimals),
+  };
+  context.Sponsor.set(newSponsor);
+  return newSponsor;
+}
+
+function createSponsorship(
+  context: Parameters<Handler>[0]["context"],
+  event: Parameters<Handler>[0]["event"],
+  sponsorEntityId: string,
+  decimals: number
+) {
+  const id = `${event.chainId}_${event.transaction.hash}_${event.logIndex}`;
+  const campaignAddress = event.srcAddress.toLowerCase();
+
+  context.Sponsorship.set({
+    amount: event.params.amount,
+    amountDisplay: formatUnits(event.params.amount, decimals),
+    block: event.block.number,
+    campaignAddress,
+    campaignId: Id.campaign(event.srcAddress, event.chainId),
+    chainId: event.chainId,
+    id,
+    logIndex: event.logIndex,
+    sender: event.params.caller.toLowerCase(),
+    sponsor_id: sponsorEntityId,
+    timestamp: event.block.timestamp,
+    token: event.params.token.toLowerCase(),
+    txHash: event.transaction.hash,
+  });
+}
+
+/* -------------------------------------------------------------------------- */
+/*                                   EXPORT                                   */
+/* -------------------------------------------------------------------------- */
+
+export const sponsorship = { handler };

--- a/envio/airdrops/mappings/v3.0/SablierMerkleInstant.ts
+++ b/envio/airdrops/mappings/v3.0/SablierMerkleInstant.ts
@@ -4,4 +4,5 @@ import * as common from "../common";
 Contract.Campaign.MerkleInstant_v3_0.ClaimInstant.handler(common.claimInstant.handler);
 Contract.Campaign.MerkleInstant_v3_0.Clawback.handler(common.clawback.handler);
 Contract.Campaign.MerkleInstant_v3_0.LowerMinFeeUSD.handler(common.lowerMinFeeUSD.handler);
+Contract.Campaign.MerkleInstant_v3_0.Sponsor.handler(common.sponsorship.handler);
 Contract.Campaign.MerkleInstant_v3_0.TransferAdmin.handler(common.transferAdmin.handler);

--- a/envio/airdrops/mappings/v3.0/SablierMerkleLL.ts
+++ b/envio/airdrops/mappings/v3.0/SablierMerkleLL.ts
@@ -5,4 +5,5 @@ Contract.Campaign.MerkleLL_v3_0.Clawback.handler(common.clawback.handler);
 Contract.Campaign.MerkleLL_v3_0.ClaimLLWithTransfer.handler(common.claimInstant.handler);
 Contract.Campaign.MerkleLL_v3_0.ClaimLLWithVesting.handler(common.claimLockup.handler);
 Contract.Campaign.MerkleLL_v3_0.LowerMinFeeUSD.handler(common.lowerMinFeeUSD.handler);
+Contract.Campaign.MerkleLL_v3_0.Sponsor.handler(common.sponsorship.handler);
 Contract.Campaign.MerkleLL_v3_0.TransferAdmin.handler(common.transferAdmin.handler);

--- a/envio/airdrops/mappings/v3.0/SablierMerkleLT.ts
+++ b/envio/airdrops/mappings/v3.0/SablierMerkleLT.ts
@@ -5,4 +5,5 @@ Contract.Campaign.MerkleLT_v3_0.Clawback.handler(common.clawback.handler);
 Contract.Campaign.MerkleLT_v3_0.ClaimLTWithTransfer.handler(common.claimInstant.handler);
 Contract.Campaign.MerkleLT_v3_0.ClaimLTWithVesting.handler(common.claimLockup.handler);
 Contract.Campaign.MerkleLT_v3_0.LowerMinFeeUSD.handler(common.lowerMinFeeUSD.handler);
+Contract.Campaign.MerkleLT_v3_0.Sponsor.handler(common.sponsorship.handler);
 Contract.Campaign.MerkleLT_v3_0.TransferAdmin.handler(common.transferAdmin.handler);

--- a/envio/airdrops/mappings/v3.0/SablierMerkleVCA.ts
+++ b/envio/airdrops/mappings/v3.0/SablierMerkleVCA.ts
@@ -7,4 +7,5 @@ Contract.Campaign.MerkleVCA_v3_0.ClaimVCA.handler(claimVCA.handler);
 Contract.Campaign.MerkleVCA_v3_0.Clawback.handler(common.clawback.handler);
 Contract.Campaign.MerkleVCA_v3_0.EnableRedistribution.handler(redistributionEnabled.handler);
 Contract.Campaign.MerkleVCA_v3_0.LowerMinFeeUSD.handler(common.lowerMinFeeUSD.handler);
+Contract.Campaign.MerkleVCA_v3_0.Sponsor.handler(common.sponsorship.handler);
 Contract.Campaign.MerkleVCA_v3_0.TransferAdmin.handler(common.transferAdmin.handler);

--- a/envio/common/usdc.ts
+++ b/envio/common/usdc.ts
@@ -1,0 +1,39 @@
+import {
+  arbitrum,
+  avalanche,
+  base,
+  baseSepolia,
+  bsc,
+  gnosis,
+  linea,
+  mainnet,
+  optimism,
+  polygon,
+  scroll,
+  sepolia,
+  sonic,
+  zksync,
+} from "sablier/evm/chains";
+
+export type UsdcInfo = {
+  address: string;
+  decimals: number;
+};
+
+/** USDC contract addresses and decimals per chain */
+export const usdc: Record<number, UsdcInfo> = {
+  [mainnet.id]: { address: "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48", decimals: 6 },
+  [optimism.id]: { address: "0x0b2c639c533813f4aa9d7837caf62653d097ff85", decimals: 6 },
+  [bsc.id]: { address: "0x8ac76a51cc950d9822d68b83fe1ad97b32cd580d", decimals: 18 }, // Binance-Peg
+  [gnosis.id]: { address: "0xddafbb505ad214d7b80b1f830fccc89b60fb7a83", decimals: 6 },
+  [polygon.id]: { address: "0x3c499c542cef5e3811e1192ce70d8cc03d5c3359", decimals: 6 },
+  [sonic.id]: { address: "0x29219dd400f2bf60e5a23d13be72b486d4038894", decimals: 6 },
+  [zksync.id]: { address: "0x1d17cbcf0d6d143135ae902365d2e5e2a16538d4", decimals: 6 },
+  [base.id]: { address: "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913", decimals: 6 },
+  [arbitrum.id]: { address: "0xaf88d065e77c8cc2239327c5edb3a432268e5831", decimals: 6 },
+  [avalanche.id]: { address: "0xb97ef9ef8734c71904d8002f8b6bc66dd9c48a6e", decimals: 6 },
+  [linea.id]: { address: "0x176211869ca2b568f2a7d4ee941e073a821ee1ff", decimals: 6 },
+  [baseSepolia.id]: { address: "0x036cbd53842c5426634e7929541ec2318f3dcf7e", decimals: 6 },
+  [scroll.id]: { address: "0x06efdbff2a14a7c8e15944d1f4a48f9f95f663a4", decimals: 6 },
+  [sepolia.id]: { address: "0x1c7d4b196cb0c7b01d743fbc6116a902379c7238", decimals: 6 },
+};

--- a/events/airdrops.ts
+++ b/events/airdrops.ts
@@ -56,6 +56,14 @@ const LOWER_MIN_FEE_EVENTS: Record<Sablier.Version.Airdrops, readonly string[]> 
   "v3.0": ["LowerMinFeeUSD"],
 };
 
+const SPONSOR_EVENTS: Record<Sablier.Version.Airdrops, readonly string[]> = {
+  "v1.1": [],
+  "v1.2": [],
+  "v1.3": [],
+  "v2.0": [],
+  "v3.0": ["Sponsor"],
+};
+
 function get(
   version: Sablier.Version.Airdrops,
   contractName: string,
@@ -84,6 +92,7 @@ function campaign(
     ...LOWER_MIN_FEE_EVENTS[version].map((event) =>
       get(version, contractName, event, ["airdrops"])
     ),
+    ...SPONSOR_EVENTS[version].map((event) => get(version, contractName, event, ["airdrops"])),
   ];
 }
 

--- a/schema/airdrops/sponsor.graphql
+++ b/schema/airdrops/sponsor.graphql
@@ -1,0 +1,39 @@
+"""
+An address that has sponsored a Sablier airdrop campaign via the Sponsor event.
+"""
+type Sponsor @entity(immutable: false) {
+  """
+  Unique identifier: `{chainId}_{address}`
+  """
+  id: String!
+
+  """
+  Address of the sponsor.
+  """
+  address: String!
+
+  """
+  The chain ID where the sponsorship was made (sponsorships are chain-specific).
+  """
+  chainId: Int!
+
+  """
+  Number of sponsorships made by this sponsor.
+  """
+  sponsorshipCount: Int!
+
+  """
+  List of individual sponsorship events by this sponsor.
+  """
+  sponsorships: [Sponsorship!]! @derivedFrom(field: "sponsor")
+
+  """
+  Cumulative raw USDC amount paid by the sponsor.
+  """
+  totalAmount: BigInt!
+
+  """
+  Human-readable cumulative USDC amount paid by the sponsor (e.g., "1729.12").
+  """
+  totalAmountDisplay: String!
+}

--- a/schema/airdrops/sponsorship.graphql
+++ b/schema/airdrops/sponsorship.graphql
@@ -1,0 +1,69 @@
+"""
+A single Sponsor event on a campaign contract. Immutable — one per Sponsor event.
+"""
+type Sponsorship @entity(immutable: true) {
+  """
+  Unique identifier: `{chainId}_{txHash}_{logIndex}`
+  """
+  id: String!
+
+  """
+  Raw USDC amount.
+  """
+  amount: BigInt!
+
+  """
+  Human-readable USDC amount (e.g., "1719.12").
+  """
+  amountDisplay: String!
+
+  """
+  Block number of the transaction.
+  """
+  block: Int!
+
+  """
+  Address of the campaign contract that emitted the Sponsor event.
+  """
+  campaignAddress: String!
+
+  """
+  ID of the campaign entity (format: `{address}-{chainId}`).
+  """
+  campaignId: String!
+
+  """
+  The ID of the chain where the sponsorship occurred.
+  """
+  chainId: Int!
+
+  """
+  Log index of the Sponsor event within the block.
+  """
+  logIndex: Int!
+
+  """
+  Address of the caller who initiated the sponsor transaction.
+  """
+  sender: String!
+
+  """
+  The sponsor who made this payment.
+  """
+  sponsor: Sponsor!
+
+  """
+  Unix timestamp of the transaction.
+  """
+  timestamp: Int!
+
+  """
+  Address of the USDC token used for payment.
+  """
+  token: String!
+
+  """
+  Hash of the transaction.
+  """
+  txHash: String!
+}

--- a/schema/merger.ts
+++ b/schema/merger.ts
@@ -31,6 +31,7 @@ const PROTOCOL_MAP: Record<Indexer.Name, ProtocolSchemaConfig> = {
   airdrops: {
     generators: BASE.generators,
     indexerSpecific: ["action", "activity", "campaign", "factory", "tranche"],
+    vendorSpecific: { envio: ["sponsor", "sponsorship"], graph: [] },
   },
   flow: {
     common: ["action", "batch", "contract", "deprecated-stream"],

--- a/src/schemas/airdrops.graphql
+++ b/src/schemas/airdrops.graphql
@@ -459,3 +459,95 @@ type Tranche @entity(immutable: true) {
   """
   startPercentage: BigInt!
 }
+
+"""
+An address that has sponsored a Sablier airdrop campaign via the Sponsor event.
+"""
+type Sponsor @entity(immutable: false) {
+  """
+  Unique identifier: `{chainId}_{address}`
+  """
+  id: String!
+  """
+  Address of the sponsor.
+  """
+  address: String!
+  """
+  The chain ID where the sponsorship was made (sponsorships are chain-specific).
+  """
+  chainId: Int!
+  """
+  Number of sponsorships made by this sponsor.
+  """
+  sponsorshipCount: Int!
+  """
+  List of individual sponsorship events by this sponsor.
+  """
+  sponsorships: [Sponsorship!]! @derivedFrom(field: "sponsor")
+  """
+  Cumulative raw USDC amount paid by the sponsor.
+  """
+  totalAmount: BigInt!
+  """
+  Human-readable cumulative USDC amount paid by the sponsor (e.g., "1729.12").
+  """
+  totalAmountDisplay: String!
+}
+
+"""
+A single Sponsor event on a campaign contract. Immutable — one per Sponsor event.
+"""
+type Sponsorship @entity(immutable: true) {
+  """
+  Unique identifier: `{chainId}_{txHash}_{logIndex}`
+  """
+  id: String!
+  """
+  Raw USDC amount.
+  """
+  amount: BigInt!
+  """
+  Human-readable USDC amount (e.g., "1719.12").
+  """
+  amountDisplay: String!
+  """
+  Block number of the transaction.
+  """
+  block: Int!
+  """
+  Address of the campaign contract that emitted the Sponsor event.
+  """
+  campaignAddress: String!
+  """
+  ID of the campaign entity (format: `{address}-{chainId}`).
+  """
+  campaignId: String!
+  """
+  The ID of the chain where the sponsorship occurred.
+  """
+  chainId: Int!
+  """
+  Log index of the Sponsor event within the block.
+  """
+  logIndex: Int!
+  """
+  Address of the caller who initiated the sponsor transaction.
+  """
+  sender: String!
+  """
+  The sponsor who made this payment.
+  """
+  sponsor: Sponsor!
+  """
+  Unix timestamp of the transaction.
+  """
+  timestamp: Int!
+  """
+  Address of the USDC token used for payment.
+  """
+  token: String!
+  """
+  Hash of the transaction.
+  """
+  txHash: String!
+}


### PR DESCRIPTION
This PR adds support for airdrop sponsorship tracking. 

Note: Javascript recenlty added support for [import attributes](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with). I tried using this to avoid duplicating the USDC addresses but it will still violate the no-envio-external-imports rule.


<img width="1408" height="771" alt="Screenshot 2026-03-30 at 13 34 24" src="https://github.com/user-attachments/assets/17ff0f88-a2c6-404f-b7be-7e7bf9e1eb4a" />
