### PR TITLE
fix: reference the correct prices-sync recipe (not a non-existent just price-data-sync)

### DIFF
--- a/cli/commands/prices/check/run.ts
+++ b/cli/commands/prices/check/run.ts
@@ -133,7 +133,7 @@ export const handler = () =>
 
       errorTable.push(
         [colors.error("❌ Price data is out of sync!")],
-        [colors.value(`Run ${colors.highlight("just price-data-sync")} to fix and commit changes.`)]
+        [colors.value(`Run ${colors.highlight("just envio::prices-sync")} to fix and commit changes.`)]
       );
 
       yield* Console.log(errorTable.toString());

--- a/cli/commands/prices/check/run.ts
+++ b/cli/commands/prices/check/run.ts
@@ -133,7 +133,11 @@ export const handler = () =>
 
       errorTable.push(
         [colors.error("❌ Price data is out of sync!")],
-        [colors.value(`Run ${colors.highlight("just envio::prices-sync")} to fix and commit changes.`)]
+        [
+          colors.value(
+            `Run ${colors.highlight("just envio::prices-sync")} to fix and commit changes.`
+          ),
+        ]
       );
 
       yield* Console.log(errorTable.toString());

--- a/envio/analytics/effects/coingecko.ts
+++ b/envio/analytics/effects/coingecko.ts
@@ -49,7 +49,7 @@ function createEffect(currency: string) {
  *
  * 1. Add the coin configuration to the `coinConfigs` object below
  * 2. Update the `@sablier/price-data` package with the new coin's historical data
- * 3. Run `just price-data-sync` to copy the TSV file to `.envio/cache/`
+ * 3. Run `just envio::prices-sync` to copy the TSV file to `.envio/cache/`
  */
 export const coinConfigs: Record<string, CoinConfig> = {
   [avalanche.nativeCurrency.symbol]: {


### PR DESCRIPTION
The prices out-of-sync error and a doc comment both tell users to run `just price-data-sync`, but no such recipe exists.

- `cli/commands/prices/check/run.ts:136` — user-facing error: *"Run `just price-data-sync` to fix and commit changes."*
- `envio/analytics/effects/coingecko.ts:52` — doc comment: *"Run `just price-data-sync` to copy the TSV file…"*

The actual recipe is `prices-sync` in the `envio` module (`recipes/envio.just`), invoked as `just envio::prices-sync` — which is what every other reference uses (`AGENTS.md`, `envio/AGENTS.md`, `cli/AGENTS.md`, `.github/workflows/update-prices.yml`). Running `just price-data-sync` errors with `Justfile does not contain recipe 'price-data-sync'`.

This points both references at the real recipe. Docs/message only.
