### PR TITLE
fix(analytics): persist isOnlyAirdropClaimer changes for existing users

### DIFF
--- a/envio/analytics/store/entity-user.ts
+++ b/envio/analytics/store/entity-user.ts
@@ -70,11 +70,11 @@ async function upsert(context: HandlerContext, event: Envio.Event, params: Param
   let user = params.entity;
   if (user) {
     const newAirdropClaimerStatus = user.isOnlyAirdropClaimer && Boolean(params.isAirdropClaim);
-    user = {
-      ...user,
-      isOnlyAirdropClaimer: newAirdropClaimerStatus,
-    };
     if (newAirdropClaimerStatus !== user.isOnlyAirdropClaimer) {
+      user = {
+        ...user,
+        isOnlyAirdropClaimer: newAirdropClaimerStatus,
+      };
       context.User.set(user);
     }
   } else {


### PR DESCRIPTION
## Bug

In `envio/analytics/store/entity-user.ts`, the existing-user branch of `upsert` never persists a change to `isOnlyAirdropClaimer`:

```ts
const newAirdropClaimerStatus = user.isOnlyAirdropClaimer && Boolean(params.isAirdropClaim);
user = {
  ...user,
  isOnlyAirdropClaimer: newAirdropClaimerStatus,
};
if (newAirdropClaimerStatus !== user.isOnlyAirdropClaimer) {   // always false
  context.User.set(user);
}
```

`user` is reassigned so that `user.isOnlyAirdropClaimer === newAirdropClaimerStatus`, so the guard `newAirdropClaimerStatus !== user.isOnlyAirdropClaimer` is always `false` and `context.User.set(user)` is unreachable for existing users.

## Impact

An address that first appears via an airdrop claim is stored with `isOnlyAirdropClaimer = true`. When that address later performs a non-claim Sablier action (e.g. a Lockup withdrawal, `isAirdropClaim = false`), `newAirdropClaimerStatus` becomes `false`, but the entity is never re-persisted — so the address stays `isOnlyAirdropClaimer = true` permanently and is misclassified.

(The comment above this block waives correctness only for the multiple-events-in-one-tx case; it doesn't cover this dead write.)

## Fix

Compare against the previous value before reassigning, and only build/persist the updated entity when the status actually changes.
