### PR TITLE
fix(airdrops): accumulate tranche bounds

### DIFF
--- a/envio/airdrops/store/entity-campaign.ts
+++ b/envio/airdrops/store/entity-campaign.ts
@@ -234,29 +234,28 @@ function addTranchesWithPercentages(
   campaign: Entity<"Campaign">,
   tranches: TrancheWithPercentage[]
 ): void {
-  // The start time of the stream is the first tranche's start time, so we use zero for the initial duration.
-  let previous = { duration: 0n, unlockPercentage: 0n };
+  let cumulativeDuration = 0n;
+  let cumulativePercentage = 0n;
 
   for (let i = 0; i < tranches.length; i++) {
     const current = tranches[i];
+    const startDuration = cumulativeDuration;
+    const startPercentage = cumulativePercentage;
+    cumulativeDuration += current.duration;
+    cumulativePercentage += current.unlockPercentage;
 
     const tranche: Entity<"Tranche"> = {
       campaign_id: campaign.id,
       duration: current.duration,
-      endDuration: previous.duration + current.duration,
-      endPercentage: previous.unlockPercentage + current.unlockPercentage,
+      endDuration: cumulativeDuration,
+      endPercentage: cumulativePercentage,
       id: Id.trancheCampaign(campaign.id, i),
       percentage: current.unlockPercentage,
       position: BigInt(i),
-      startDuration: previous.duration,
-      startPercentage: previous.unlockPercentage,
+      startDuration,
+      startPercentage,
     };
     context.Tranche.set(tranche);
-
-    previous = {
-      duration: tranche.endDuration,
-      unlockPercentage: tranche.endPercentage,
-    };
   }
 }
 

--- a/envio/airdrops/store/entity-campaign.ts
+++ b/envio/airdrops/store/entity-campaign.ts
@@ -253,7 +253,10 @@ function addTranchesWithPercentages(
     };
     context.Tranche.set(tranche);
 
-    previous = current;
+    previous = {
+      duration: tranche.endDuration,
+      unlockPercentage: tranche.endPercentage,
+    };
   }
 }
 

--- a/graph/airdrops/store/entity-campaign.ts
+++ b/graph/airdrops/store/entity-campaign.ts
@@ -179,25 +179,27 @@ function addTranchesWithPercentages(
   campaign: Entity.Campaign,
   tranches: TrancheWithPercentage[]
 ): Entity.Campaign {
-  // The start time of the stream is the first tranche's start time, so we use zero for the initial duration.
-  let previous = new TrancheWithPercentage(ZERO, ZERO);
+  let cumulativeDuration = ZERO;
+  let cumulativePercentage = ZERO;
 
   for (let i = 0; i < tranches.length; i++) {
     const current = tranches[i];
+    const startDuration = cumulativeDuration;
+    const startPercentage = cumulativePercentage;
+    cumulativeDuration = cumulativeDuration.plus(current.duration);
+    cumulativePercentage = cumulativePercentage.plus(current.unlockPercentage);
 
     const id = Id.trancheCampaign(campaign.id, i);
     const tranche = new Entity.Tranche(id);
     tranche.campaign = campaign.id;
     tranche.duration = current.duration;
-    tranche.endDuration = previous.duration.plus(current.duration);
-    tranche.endPercentage = previous.unlockPercentage.plus(current.unlockPercentage);
+    tranche.endDuration = cumulativeDuration;
+    tranche.endPercentage = cumulativePercentage;
     tranche.percentage = current.unlockPercentage;
     tranche.position = BigInt.fromU32(i);
-    tranche.startDuration = previous.duration;
-    tranche.startPercentage = previous.unlockPercentage;
+    tranche.startDuration = startDuration;
+    tranche.startPercentage = startPercentage;
     tranche.save();
-
-    previous = new TrancheWithPercentage(tranche.endPercentage, tranche.endDuration);
   }
 
   return campaign;

--- a/graph/airdrops/store/entity-campaign.ts
+++ b/graph/airdrops/store/entity-campaign.ts
@@ -197,7 +197,7 @@ function addTranchesWithPercentages(
     tranche.startPercentage = previous.unlockPercentage;
     tranche.save();
 
-    previous = tranches[i];
+    previous = new TrancheWithPercentage(tranche.endPercentage, tranche.endDuration);
   }
 
   return campaign;


### PR DESCRIPTION
Carries cumulative tranche duration and unlock percentage forward in both Envio and Graph. LT `startDuration`, `endDuration`, `startPercentage`, and `endPercentage` now remain cumulative from the third tranche onward and match the schema contract.

Existing campaigns need a reindex to pick up the corrected values.

Closes #347