### PR TITLE
fix(graph): index v3 and v4 Lockup contracts

### DIFF
--- a/graph/streams/mappings/lockup/v3.0/SablierLockup/create-dynamic.ts
+++ b/graph/streams/mappings/lockup/v3.0/SablierLockup/create-dynamic.ts
@@ -8,6 +8,8 @@ export function handle_SablierLockup_v3_0_CreateLockupDynamicStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createDynamic(
     event,
     {

--- a/graph/streams/mappings/lockup/v3.0/SablierLockup/create-linear.ts
+++ b/graph/streams/mappings/lockup/v3.0/SablierLockup/create-linear.ts
@@ -7,6 +7,8 @@ export function handle_SablierLockup_v3_0_CreateLockupLinearStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createLinear(
     event,
     {

--- a/graph/streams/mappings/lockup/v3.0/SablierLockup/create-tranched.ts
+++ b/graph/streams/mappings/lockup/v3.0/SablierLockup/create-tranched.ts
@@ -8,6 +8,8 @@ export function handle_SablierLockup_v3_0_CreateLockupTranchedStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createTranched(
     event,
     {

--- a/graph/streams/mappings/lockup/v4.0/SablierLockup/create-dynamic.ts
+++ b/graph/streams/mappings/lockup/v4.0/SablierLockup/create-dynamic.ts
@@ -8,6 +8,8 @@ export function handle_SablierLockup_v4_0_CreateLockupDynamicStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createDynamic(
     event,
     {

--- a/graph/streams/mappings/lockup/v4.0/SablierLockup/create-linear.ts
+++ b/graph/streams/mappings/lockup/v4.0/SablierLockup/create-linear.ts
@@ -7,6 +7,8 @@ export function handle_SablierLockup_v4_0_CreateLockupLinearStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createLinear(
     event,
     {

--- a/graph/streams/mappings/lockup/v4.0/SablierLockup/create-tranched.ts
+++ b/graph/streams/mappings/lockup/v4.0/SablierLockup/create-tranched.ts
@@ -8,6 +8,8 @@ export function handle_SablierLockup_v4_0_CreateLockupTranchedStream(
   const params = event.params;
   const commonParams = params.commonParams;
 
+  Store.Contract.loadOrCreate(event.address);
+
   Store.Stream.createTranched(
     event,
     {


### PR DESCRIPTION
The v3.0 and v4.0 Lockup create handlers now load or create the `Contract` entity before indexing linear, dynamic, and tranched streams.

This aligns The Graph with older Lockup handlers and Envio, so contract-based consumers such as DefiLlama's Sei TVL adapter don't miss current deployments.

Closes #346