### PR TITLE
Add deployment metadata to public indexers

### DIFF
--- a/cli/commands/codegen/envio-config/config-types.ts
+++ b/cli/commands/codegen/envio-config/config-types.ts
@@ -53,6 +53,7 @@ export namespace EnvioConfig {
    */
   export type TopSection = {
     name: string;
+    handlers?: string;
     ecosystem: "evm";
     address_format: "checksum" | "lowercase";
     schema: string;

--- a/cli/commands/codegen/envio-config/top-sections.ts
+++ b/cli/commands/codegen/envio-config/top-sections.ts
@@ -11,6 +11,7 @@ function get(name: string): EnvioConfig.TopSection {
     name: `sablier-${name}`,
     address_format: "lowercase",
     ecosystem: "evm",
+    handlers: name === "analytics" ? undefined : "handlers",
     schema: `${name}.graphql`,
     field_selection: {
       transaction_fields: ["from", "hash", "to", "transactionIndex", "value"],

--- a/cli/commands/codegen/graph-manifest/index.ts
+++ b/cli/commands/codegen/graph-manifest/index.ts
@@ -4,6 +4,7 @@ import type { Indexer } from "../../../../src/types.js";
 import { CodegenError } from "../errors.js";
 import type { GraphManifest } from "./manifest-types.js";
 import { createSources } from "./sources/index.js";
+import { createIndexerInfoSource } from "./sources/indexer-info.js";
 import { topSections } from "./top-sections.js";
 
 /**
@@ -19,7 +20,8 @@ export function createGraphManifest(target: Indexer.GraphTarget, chainId: number
       return yield* Effect.fail(new CodegenError.ContractsNotFound(target, chainId));
     }
 
-    const sourcesByType = _.groupBy(sources, "_type");
+    const indexerInfoSource = createIndexerInfoSource(target, sources);
+    const sourcesByType = _.groupBy([indexerInfoSource, ...sources], "_type");
     const dataSources = _.map(sourcesByType["data-source"], (source) => _.omit(source, "_type"));
     const templates = _.map(sourcesByType.template, (source) => _.omit(source, "_type"));
 

--- a/cli/commands/codegen/graph-manifest/manifest-types.ts
+++ b/cli/commands/codegen/graph-manifest/manifest-types.ts
@@ -34,10 +34,20 @@ export namespace GraphManifest {
     };
   }
   export type Context = {
-    alias: ContextItem.String;
+    alias?: ContextItem.String;
     chainId: ContextItem.BigInt;
-    version: ContextItem.String;
+    commitHash?: ContextItem.String;
+    deployedAt?: ContextItem.BigInt;
     lockups?: ContextItem.ListAddress;
+    version?: ContextItem.String;
+    versionLabel?: ContextItem.String;
+  };
+
+  export type BlockHandler = {
+    handler: "handleIndexerInfo";
+    filter: {
+      kind: "once";
+    };
   };
 
   export type EventHandler = {
@@ -72,6 +82,7 @@ export namespace GraphManifest {
     kind: string;
     language: string;
     abis: ABI[];
+    blockHandlers?: BlockHandler[];
     entities: string[];
     eventHandlers: EventHandler[];
   };

--- a/cli/commands/codegen/graph-manifest/sources/indexer-info.ts
+++ b/cli/commands/codegen/graph-manifest/sources/indexer-info.ts
@@ -1,0 +1,80 @@
+import type { Indexer } from "../../../../../src/index.js";
+import type { GraphManifest } from "../manifest-types.js";
+
+const DEVELOPMENT = "development";
+
+/**
+ * Creates a dedicated initialization source for deployment metadata.
+ */
+export function createIndexerInfoSource(
+  target: Indexer.GraphTarget,
+  sources: GraphManifest.Source[]
+): GraphManifest.Source {
+  const dataSources = sources.filter((source) => source._type === "data-source");
+  const referenceSource = dataSources[0];
+  if (!referenceSource) {
+    throw new Error(`Cannot create IndexerInfo source without a data source for ${target}`);
+  }
+
+  const referenceABI = referenceSource.mapping.abis.find(
+    (abi) => abi.name === referenceSource.source.abi
+  );
+  if (!referenceABI) {
+    throw new Error(`Cannot resolve reference ABI for the ${target} IndexerInfo source`);
+  }
+  if (!referenceSource.context) {
+    throw new Error(`Cannot resolve chain context for the ${target} IndexerInfo source`);
+  }
+
+  const startBlock = Math.min(
+    ...dataSources.map((source) => {
+      if (source.source.startBlock === undefined) {
+        throw new Error(`Missing start block for ${source.name}`);
+      }
+      return source.source.startBlock;
+    })
+  );
+
+  return {
+    _type: "data-source",
+    context: {
+      chainId: referenceSource.context.chainId,
+      commitHash: {
+        data: DEVELOPMENT,
+        type: "String",
+      },
+      deployedAt: {
+        data: "0",
+        type: "BigInt",
+      },
+      versionLabel: {
+        data: DEVELOPMENT,
+        type: "String",
+      },
+    },
+    kind: "ethereum",
+    mapping: {
+      abis: [referenceABI],
+      apiVersion: referenceSource.mapping.apiVersion,
+      blockHandlers: [
+        {
+          filter: {
+            kind: "once",
+          },
+          handler: "handleIndexerInfo",
+        },
+      ],
+      entities: ["IndexerInfo"],
+      eventHandlers: [],
+      file: "../mappings/indexer-info.ts",
+      kind: referenceSource.mapping.kind,
+      language: referenceSource.mapping.language,
+    },
+    name: "IndexerInfo",
+    network: referenceSource.network,
+    source: {
+      abi: referenceABI.name,
+      startBlock,
+    },
+  };
+}

--- a/cli/commands/graph/deploy/all/run.ts
+++ b/cli/commands/graph/deploy/all/run.ts
@@ -23,6 +23,7 @@ import {
 import { finishSpinner, startSpinner } from "../../../../utils/spinner.js";
 import { extractDeploymentId } from "../../../../utils/text.js";
 import { extractDeployFailureMessage, hasVersionLabelConflict } from "../helpers.js";
+import { prepareDeploymentManifest } from "../indexer-info.js";
 
 /** Absolute path to the graph-cli binary. Using this instead of `pnpm exec graph` because
  * pnpm exec resolves binaries from the cwd's nearest node_modules, which fails when cwd is
@@ -291,14 +292,6 @@ function deployToChain(
   const indexerName = indexerConfig.name;
   const manifestPath = paths.graph.manifest(indexer, deployment.chainId);
   const workingDir = join(ROOT_DIR, "graph", indexer);
-  const command = PlatformCommand.make(
-    GRAPH_BIN,
-    "deploy",
-    "--version-label",
-    versionLabel,
-    indexerName,
-    manifestPath
-  ).pipe(PlatformCommand.workingDirectory(workingDir));
 
   return Effect.gen(function* () {
     const spinner = yield* startSpinner(formatDeployAttemptMessage(deployment, 1));
@@ -318,81 +311,98 @@ function deployToChain(
     }
 
     let attempts = 0;
+    return yield* Effect.scoped(
+      Effect.gen(function* () {
+        const deploymentManifest = yield* prepareDeploymentManifest(manifestPath, versionLabel);
+        const command = PlatformCommand.make(
+          GRAPH_BIN,
+          "deploy",
+          "--version-label",
+          versionLabel,
+          indexerName,
+          deploymentManifest
+        ).pipe(PlatformCommand.workingDirectory(workingDir));
+        const executeDeploymentAttempt = (attempt: number) =>
+          Effect.scoped(
+            Effect.gen(function* () {
+              const executor = yield* CommandExecutor.CommandExecutor;
+              const process = yield* executor
+                .start(command)
+                .pipe(
+                  Effect.mapError((error) =>
+                    toDeployProcessError(commandStr, normalizeErrorMessage(error))
+                  )
+                );
+              const [stdoutChunks, stderrChunks, exitCode] = yield* Effect.all([
+                Stream.runCollect(process.stdout),
+                Stream.runCollect(process.stderr),
+                process.exitCode,
+              ]).pipe(
+                Effect.mapError((error) =>
+                  toDeployProcessError(commandStr, normalizeErrorMessage(error))
+                )
+              );
 
-    const executeDeploymentAttempt = (attempt: number) =>
-      Effect.scoped(
-        Effect.gen(function* () {
-          const executor = yield* CommandExecutor.CommandExecutor;
-          const process = yield* executor
-            .start(command)
-            .pipe(
-              Effect.mapError((error) =>
-                toDeployProcessError(commandStr, normalizeErrorMessage(error))
-              )
-            );
-          const [stdoutChunks, stderrChunks, exitCode] = yield* Effect.all([
-            Stream.runCollect(process.stdout),
-            Stream.runCollect(process.stderr),
-            process.exitCode,
-          ]).pipe(
-            Effect.mapError((error) =>
-              toDeployProcessError(commandStr, normalizeErrorMessage(error))
-            )
+              const stdout = chunksToString(stdoutChunks);
+              const stderr = chunksToString(stderrChunks);
+
+              yield* logger.log(`[attempt ${attempt}] STDOUT:\n${stdout}`);
+              if (stderr.trim().length > 0) {
+                yield* logger.log(`[attempt ${attempt}] STDERR:\n${stderr}`);
+              }
+
+              if (exitCode !== 0) {
+                const errorMessage = extractDeployFailureMessage(stdout, stderr, exitCode);
+
+                if (isTransientDeployFailure(stdout, stderr)) {
+                  return yield* new TransientDeployError({
+                    chainSlug: deployment.chainSlug,
+                    message: errorMessage,
+                  });
+                }
+
+                return yield* toDeployProcessError(commandStr, errorMessage, exitCode);
+              }
+
+              const deploymentId = extractDeploymentId(stdout);
+              return { deploymentId, indexerName, success: true } as const;
+            })
           );
 
-          const stdout = chunksToString(stdoutChunks);
-          const stderr = chunksToString(stderrChunks);
-
-          yield* logger.log(`[attempt ${attempt}] STDOUT:\n${stdout}`);
-          if (stderr.trim().length > 0) {
-            yield* logger.log(`[attempt ${attempt}] STDERR:\n${stderr}`);
-          }
-
-          if (exitCode !== 0) {
-            const errorMessage = extractDeployFailureMessage(stdout, stderr, exitCode);
-
-            if (isTransientDeployFailure(stdout, stderr)) {
-              return yield* new TransientDeployError({
-                chainSlug: deployment.chainSlug,
-                message: errorMessage,
-              });
-            }
-
-            return yield* toDeployProcessError(commandStr, errorMessage, exitCode);
-          }
-
-          const deploymentId = extractDeploymentId(stdout);
-          return { deploymentId, indexerName, success: true } as const;
-        })
-      );
-
-    const retryPolicy = DEPLOY_RETRY_SCHEDULE.pipe(
-      Schedule.whileInput((error: DeployAttemptError) => error instanceof TransientDeployError),
-      Schedule.tapOutput(([delay, retryIndex]) => {
-        const retryMessage = formatRetryMessage(deployment, retryIndex, delay);
-        return Effect.all([spinner.setText(retryMessage), logger.log(`⚠️  ${retryMessage}`)]).pipe(
-          Effect.orDie,
-          Effect.asVoid
+        const retryPolicy = DEPLOY_RETRY_SCHEDULE.pipe(
+          Schedule.whileInput((error: DeployAttemptError) => error instanceof TransientDeployError),
+          Schedule.tapOutput(([delay, retryIndex]) => {
+            const retryMessage = formatRetryMessage(deployment, retryIndex, delay);
+            return Effect.all([
+              spinner.setText(retryMessage),
+              logger.log(`⚠️  ${retryMessage}`),
+            ]).pipe(Effect.orDie, Effect.asVoid);
+          })
         );
-      })
-    );
 
-    return yield* Effect.gen(function* () {
-      const result = yield* Effect.gen(function* () {
-        const attempt = yield* Effect.sync(() => {
-          attempts += 1;
-          return attempts;
+        const result = yield* Effect.gen(function* () {
+          const result = yield* Effect.gen(function* () {
+            const attempt = yield* Effect.sync(() => {
+              attempts += 1;
+              return attempts;
+            });
+
+            yield* spinner.setText(formatDeployAttemptMessage(deployment, attempt));
+            return yield* executeDeploymentAttempt(attempt);
+          }).pipe(Effect.retry(retryPolicy));
+
+          yield* finishSpinner(
+            spinner,
+            "success",
+            `Successfully deployed to ${deployment.chainName}`
+          );
+          yield* logger.log(chalk.green(`✅ Successfully deployed to ${deployment.chainName}`));
+
+          return result;
         });
-
-        yield* spinner.setText(formatDeployAttemptMessage(deployment, attempt));
-        return yield* executeDeploymentAttempt(attempt);
-      }).pipe(Effect.retry(retryPolicy));
-
-      yield* finishSpinner(spinner, "success", `Successfully deployed to ${deployment.chainName}`);
-      yield* logger.log(chalk.green(`✅ Successfully deployed to ${deployment.chainName}`));
-
-      return result;
-    }).pipe(
+        return result;
+      })
+    ).pipe(
       Effect.catchAll((error) => {
         const errorMessage = formatFinalDeployError(error, attempts);
         return finishSpinner(

--- a/cli/commands/graph/deploy/all/run.ts
+++ b/cli/commands/graph/deploy/all/run.ts
@@ -381,25 +381,22 @@ function deployToChain(
         );
 
         const result = yield* Effect.gen(function* () {
-          const result = yield* Effect.gen(function* () {
-            const attempt = yield* Effect.sync(() => {
-              attempts += 1;
-              return attempts;
-            });
+          const attempt = yield* Effect.sync(() => {
+            attempts += 1;
+            return attempts;
+          });
 
-            yield* spinner.setText(formatDeployAttemptMessage(deployment, attempt));
-            return yield* executeDeploymentAttempt(attempt);
-          }).pipe(Effect.retry(retryPolicy));
+          yield* spinner.setText(formatDeployAttemptMessage(deployment, attempt));
+          return yield* executeDeploymentAttempt(attempt);
+        }).pipe(Effect.retry(retryPolicy));
 
-          yield* finishSpinner(
-            spinner,
-            "success",
-            `Successfully deployed to ${deployment.chainName}`
-          );
-          yield* logger.log(chalk.green(`✅ Successfully deployed to ${deployment.chainName}`));
+        yield* finishSpinner(
+          spinner,
+          "success",
+          `Successfully deployed to ${deployment.chainName}`
+        );
+        yield* logger.log(chalk.green(`✅ Successfully deployed to ${deployment.chainName}`));
 
-          return result;
-        });
         return result;
       })
     ).pipe(

--- a/cli/commands/graph/deploy/indexer-info.ts
+++ b/cli/commands/graph/deploy/indexer-info.ts
@@ -1,0 +1,93 @@
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import { CommandExecutor, FileSystem, Command as PlatformCommand } from "@effect/platform";
+import { Clock, Effect } from "effect";
+import * as yaml from "js-yaml";
+import { ROOT_DIR } from "../../../utils/paths.js";
+import type { GraphManifest } from "../../codegen/graph-manifest/manifest-types.js";
+import { dumpYAML } from "../../codegen/helpers.js";
+
+type DeploymentMetadata = {
+  commitHash: string;
+  deployedAt: number;
+  versionLabel: string;
+};
+
+type ContextValue = {
+  data: string;
+};
+
+type DeploymentManifest = {
+  dataSources?: Array<{
+    context?: {
+      commitHash?: ContextValue;
+      deployedAt?: ContextValue;
+      versionLabel?: ContextValue;
+    };
+    name?: string;
+  }>;
+};
+
+/**
+ * Replaces the development placeholders in an IndexerInfo data source.
+ */
+export function applyIndexerInfoMetadata<T extends DeploymentManifest>(
+  manifest: T,
+  metadata: DeploymentMetadata
+): T {
+  const source = manifest.dataSources?.find((dataSource) => dataSource.name === "IndexerInfo");
+  const context = source?.context;
+  if (!context?.commitHash || !context.deployedAt || !context.versionLabel) {
+    throw new Error("IndexerInfo deployment context is missing from the Graph manifest");
+  }
+
+  context.commitHash.data = metadata.commitHash;
+  context.deployedAt.data = metadata.deployedAt.toString();
+  context.versionLabel.data = metadata.versionLabel;
+  return manifest;
+}
+
+/**
+ * Creates a temporary sibling manifest containing deployment-specific metadata.
+ * Keeping it beside the generated manifest preserves all relative schema, ABI, and mapping paths.
+ */
+export function prepareDeploymentManifest(manifestPath: string, versionLabel: string) {
+  return Effect.acquireRelease(
+    Effect.gen(function* () {
+      const executor = yield* CommandExecutor.CommandExecutor;
+      const fs = yield* FileSystem.FileSystem;
+      const [contents, commitHash, timestampMs] = yield* Effect.all([
+        fs.readFileString(manifestPath),
+        executor.string(
+          PlatformCommand.make("git", "rev-parse", "HEAD").pipe(
+            PlatformCommand.workingDirectory(ROOT_DIR)
+          )
+        ),
+        Clock.currentTimeMillis,
+      ]);
+
+      const manifest = yield* Effect.try({
+        catch: (error) => new Error(`Failed to prepare Graph manifest: ${String(error)}`),
+        try: () =>
+          applyIndexerInfoMetadata(yaml.load(contents) as DeploymentManifest, {
+            commitHash: commitHash.trim(),
+            deployedAt: Math.trunc(timestampMs / 1000),
+            versionLabel,
+          }),
+      });
+
+      const parsedPath = path.parse(manifestPath);
+      const deploymentPath = path.join(
+        parsedPath.dir,
+        `.${parsedPath.name}.deploy-${randomUUID()}${parsedPath.ext}`
+      );
+      yield* fs.writeFileString(deploymentPath, dumpYAML(manifest as GraphManifest.TopSection));
+      return deploymentPath;
+    }),
+    (deploymentPath) =>
+      FileSystem.FileSystem.pipe(
+        Effect.flatMap((fs) => fs.remove(deploymentPath)),
+        Effect.catchAll(() => Effect.void)
+      )
+  );
+}

--- a/cli/commands/graph/deploy/single/run.ts
+++ b/cli/commands/graph/deploy/single/run.ts
@@ -10,6 +10,7 @@ import { GraphDeployError, ValidationError } from "../../../../utils/errors.js";
 import { finishSpinner, startSpinner } from "../../../../utils/spinner.js";
 import { extractDeploymentId } from "../../../../utils/text.js";
 import { extractDeployFailureMessage } from "../helpers.js";
+import { prepareDeploymentManifest } from "../indexer-info.js";
 
 /* -------------------------------------------------------------------------- */
 /*                                   TYPES                                    */
@@ -192,7 +193,16 @@ export const handler = (options: CommandOptions) =>
     }
 
     // Execute deployment (no confirmation — justfile [confirm] handles it)
-    const result = yield* executeDeployment(args, workingDir, chain.name);
+    const result = yield* Effect.scoped(
+      Effect.gen(function* () {
+        const deploymentManifest = yield* prepareDeploymentManifest(
+          manifestPath,
+          options.versionLabel
+        );
+        const deploymentArgs = [...args.slice(0, -1), deploymentManifest];
+        return yield* executeDeployment(deploymentArgs, workingDir, chain.name);
+      })
+    );
 
     if (!result.success) {
       return yield* Effect.fail(

--- a/envio/airdrops/airdrops.graphql
+++ b/envio/airdrops/airdrops.graphql
@@ -69,6 +69,49 @@ type Watcher @entity(immutable: false) {
 }
 
 """
+Metadata describing the indexer deployment for one chain.
+"""
+type IndexerInfo @entity(immutable: true) {
+  """
+  The chain ID. There is one IndexerInfo entity per chain.
+  """
+  id: String!
+  """
+  The chain ID where this indexer is running.
+  """
+  chainId: BigInt!
+  """
+  Git commit from which the indexer was deployed.
+  """
+  commitHash: String!
+  """
+  Approximate Unix timestamp when the deployment was prepared. This may differ from the time at which the deployment
+  became active. Local deployments fall back to the timestamp of the first indexed block.
+  """
+  deployedAt: BigInt!
+  """
+  Public indexer key: "airdrops" or "streams".
+  """
+  indexer: String!
+  """
+  Protocols covered by this indexer.
+  """
+  protocols: [String!]!
+  """
+  First block processed by this indexer on the chain.
+  """
+  startBlock: BigInt!
+  """
+  Indexing service: "envio" or "graph".
+  """
+  vendor: String!
+  """
+  The Graph deployment version label. Unavailable for Envio deployments.
+  """
+  versionLabel: String
+}
+
+"""
 A generic entity for tracking protocol actions. There may be multiple actions for a single tx.
 """
 type Action @entity(immutable: true) {

--- a/envio/airdrops/config.yaml
+++ b/envio/airdrops/config.yaml
@@ -2,6 +2,7 @@
 name: "sablier-airdrops"
 address_format: "lowercase"
 ecosystem: "evm"
+handlers: "handlers"
 schema: "airdrops.graphql"
 field_selection:
   transaction_fields:

--- a/envio/airdrops/handlers/indexer-info.ts
+++ b/envio/airdrops/handlers/indexer-info.ts
@@ -1,0 +1,41 @@
+import { indexer } from "envio";
+import { fetchBlockTimestamp } from "../../common/effects/index.js";
+import deployment from "../indexer-info.json";
+
+indexer.onBlock(
+  {
+    name: "IndexerInfo",
+    where: ({ chain }) => ({
+      block: {
+        number: {
+          _gte: chain.startBlock,
+          _lte: chain.startBlock,
+        },
+      },
+    }),
+  },
+  async ({ block, context }) => {
+    // Preload optimization runs block handlers twice; only persist the final pass.
+    if (context.isPreload) {
+      return;
+    }
+
+    const chainId = context.chain.id;
+    const deployedAt =
+      deployment.deployedAt === null
+        ? await context.effect(fetchBlockTimestamp, { blockNumber: block.number, chainId })
+        : BigInt(deployment.deployedAt);
+
+    context.IndexerInfo.set({
+      chainId: BigInt(chainId),
+      commitHash: deployment.commitHash,
+      deployedAt,
+      id: chainId.toString(),
+      indexer: "airdrops",
+      protocols: ["airdrops"],
+      startBlock: BigInt(block.number),
+      vendor: "envio",
+      versionLabel: deployment.versionLabel ?? undefined,
+    });
+  }
+);

--- a/envio/airdrops/indexer-info.json
+++ b/envio/airdrops/indexer-info.json
@@ -1,0 +1,5 @@
+{
+  "commitHash": "development",
+  "deployedAt": null,
+  "versionLabel": null
+}

--- a/envio/airdrops/justfile
+++ b/envio/airdrops/justfile
@@ -1,7 +1,7 @@
 import "../indexer.just"
 
 # Run `just --evaluate ENVIO_HASURA_PUBLIC_AGGREGATE` to see the result
-export ENVIO_HASURA_PUBLIC_AGGREGATE := "Action&Activity&Asset&Campaign"
+export ENVIO_HASURA_PUBLIC_AGGREGATE := "Action&Activity&Asset&Campaign&IndexerInfo"
 export ENVIO_INDEXER_NAME := "airdrops"
 export INDEXER_NAME := "airdrops"
 

--- a/envio/common/effects/block-timestamp.ts
+++ b/envio/common/effects/block-timestamp.ts
@@ -1,0 +1,23 @@
+import { createEffect, S } from "envio";
+import { getClient } from "../rpc-clients.js";
+
+/**
+ * Fetches a block timestamp from RPC. Envio block handlers currently expose only the block number.
+ */
+export const fetchBlockTimestamp = createEffect(
+  {
+    cache: true,
+    input: S.tuple((t) => ({
+      blockNumber: t.item(1, S.number),
+      chainId: t.item(0, S.number),
+    })),
+    name: "blockTimestamp",
+    output: S.bigint,
+    rateLimit: false,
+  },
+  async ({ input }) => {
+    const client = getClient(input.chainId);
+    const block = await client.getBlock({ blockNumber: BigInt(input.blockNumber) });
+    return block.timestamp;
+  }
+);

--- a/envio/common/effects/index.ts
+++ b/envio/common/effects/index.ts
@@ -1,1 +1,2 @@
+export * from "./block-timestamp.js";
 export * from "./token-metadata.js";

--- a/envio/streams/config.yaml
+++ b/envio/streams/config.yaml
@@ -2,6 +2,7 @@
 name: "sablier-streams"
 address_format: "lowercase"
 ecosystem: "evm"
+handlers: "handlers"
 schema: "streams.graphql"
 field_selection:
   transaction_fields:

--- a/envio/streams/handlers/indexer-info.ts
+++ b/envio/streams/handlers/indexer-info.ts
@@ -1,0 +1,41 @@
+import { indexer } from "envio";
+import { fetchBlockTimestamp } from "../../common/effects/index.js";
+import deployment from "../indexer-info.json";
+
+indexer.onBlock(
+  {
+    name: "IndexerInfo",
+    where: ({ chain }) => ({
+      block: {
+        number: {
+          _gte: chain.startBlock,
+          _lte: chain.startBlock,
+        },
+      },
+    }),
+  },
+  async ({ block, context }) => {
+    // Preload optimization runs block handlers twice; only persist the final pass.
+    if (context.isPreload) {
+      return;
+    }
+
+    const chainId = context.chain.id;
+    const deployedAt =
+      deployment.deployedAt === null
+        ? await context.effect(fetchBlockTimestamp, { blockNumber: block.number, chainId })
+        : BigInt(deployment.deployedAt);
+
+    context.IndexerInfo.set({
+      chainId: BigInt(chainId),
+      commitHash: deployment.commitHash,
+      deployedAt,
+      id: chainId.toString(),
+      indexer: "streams",
+      protocols: ["flow", "lockup"],
+      startBlock: BigInt(block.number),
+      vendor: "envio",
+      versionLabel: deployment.versionLabel ?? undefined,
+    });
+  }
+);

--- a/envio/streams/indexer-info.json
+++ b/envio/streams/indexer-info.json
@@ -1,0 +1,5 @@
+{
+  "commitHash": "development",
+  "deployedAt": null,
+  "versionLabel": null
+}

--- a/envio/streams/justfile
+++ b/envio/streams/justfile
@@ -1,7 +1,7 @@
 import "../indexer.just"
 
 # Run `just --evaluate ENVIO_HASURA_PUBLIC_AGGREGATE` to see the result
-export ENVIO_HASURA_PUBLIC_AGGREGATE := "Asset&FlowAction&FlowBatch&FlowStream&LockupAction&LockupBatch&LockupStream"
+export ENVIO_HASURA_PUBLIC_AGGREGATE := "Asset&FlowAction&FlowBatch&FlowStream&IndexerInfo&LockupAction&LockupBatch&LockupStream"
 export ENVIO_INDEXER_NAME := "streams"
 export INDEXER_NAME := "streams"
 

--- a/envio/streams/streams.graphql
+++ b/envio/streams/streams.graphql
@@ -685,6 +685,49 @@ type LockupBatcher @entity(immutable: false) {
 }
 
 """
+Metadata describing the indexer deployment for one chain.
+"""
+type IndexerInfo @entity(immutable: true) {
+  """
+  The chain ID. There is one IndexerInfo entity per chain.
+  """
+  id: String!
+  """
+  The chain ID where this indexer is running.
+  """
+  chainId: BigInt!
+  """
+  Git commit from which the indexer was deployed.
+  """
+  commitHash: String!
+  """
+  Approximate Unix timestamp when the deployment was prepared. This may differ from the time at which the deployment
+  became active. Local deployments fall back to the timestamp of the first indexed block.
+  """
+  deployedAt: BigInt!
+  """
+  Public indexer key: "airdrops" or "streams".
+  """
+  indexer: String!
+  """
+  Protocols covered by this indexer.
+  """
+  protocols: [String!]!
+  """
+  First block processed by this indexer on the chain.
+  """
+  startBlock: BigInt!
+  """
+  Indexing service: "envio" or "graph".
+  """
+  vendor: String!
+  """
+  The Graph deployment version label. Unavailable for Envio deployments.
+  """
+  versionLabel: String
+}
+
+"""
 A Sablier protocol contract
 """
 type Contract @entity(immutable: false) {

--- a/graph/airdrops/mappings/indexer-info.ts
+++ b/graph/airdrops/mappings/indexer-info.ts
@@ -1,0 +1,25 @@
+import { ethereum } from "@graphprotocol/graph-ts";
+import { ZERO } from "../../common/constants";
+import {
+  readChainId,
+  readIndexerCommitHash,
+  readIndexerDeployedAt,
+  readIndexerVersionLabel,
+} from "../../common/context";
+import * as Entity from "../bindings/schema";
+
+export function handleIndexerInfo(block: ethereum.Block): void {
+  const chainId = readChainId();
+  const configuredDeployedAt = readIndexerDeployedAt();
+  const info = new Entity.IndexerInfo(chainId.toString());
+
+  info.chainId = chainId;
+  info.commitHash = readIndexerCommitHash();
+  info.deployedAt = configuredDeployedAt.equals(ZERO) ? block.timestamp : configuredDeployedAt;
+  info.indexer = "airdrops";
+  info.protocols = ["airdrops"];
+  info.startBlock = block.number;
+  info.vendor = "graph";
+  info.versionLabel = readIndexerVersionLabel();
+  info.save();
+}

--- a/graph/common/context.ts
+++ b/graph/common/context.ts
@@ -17,6 +17,18 @@ export function readContractVersion(): string {
   return readString("version");
 }
 
+export function readIndexerCommitHash(): string {
+  return readString("commitHash");
+}
+
+export function readIndexerDeployedAt(): BigInt {
+  return readBigInt("deployedAt");
+}
+
+export function readIndexerVersionLabel(): string {
+  return readString("versionLabel");
+}
+
 export function readLockups(): string[] {
   const context = dataSource.context();
   const value = context.get("lockups");

--- a/graph/streams/mappings/indexer-info.ts
+++ b/graph/streams/mappings/indexer-info.ts
@@ -1,0 +1,25 @@
+import { ethereum } from "@graphprotocol/graph-ts";
+import { ZERO } from "../../common/constants";
+import {
+  readChainId,
+  readIndexerCommitHash,
+  readIndexerDeployedAt,
+  readIndexerVersionLabel,
+} from "../../common/context";
+import * as Entity from "../bindings/schema";
+
+export function handleIndexerInfo(block: ethereum.Block): void {
+  const chainId = readChainId();
+  const configuredDeployedAt = readIndexerDeployedAt();
+  const info = new Entity.IndexerInfo(chainId.toString());
+
+  info.chainId = chainId;
+  info.commitHash = readIndexerCommitHash();
+  info.deployedAt = configuredDeployedAt.equals(ZERO) ? block.timestamp : configuredDeployedAt;
+  info.indexer = "streams";
+  info.protocols = ["flow", "lockup"];
+  info.startBlock = block.number;
+  info.vendor = "graph";
+  info.versionLabel = readIndexerVersionLabel();
+  info.save();
+}

--- a/recipes/envio.just
+++ b/recipes/envio.just
@@ -50,6 +50,7 @@ _deploy indexer:
     esac
     deployment_indexer="{{ indexer }}"
     deployment_branch="deployment/$deployment_indexer"
+    source_commit=$(git rev-parse HEAD)
     tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/envio-deploy.XXXXXX")
     worktree="$tmpdir/worktree"
     cleanup() {
@@ -65,6 +66,7 @@ _deploy indexer:
         airdrops | streams)
             cache_source="envio/$deployment_indexer/.envio/cache"
             cache_file="$cache_source/tokenMetadata.tsv"
+            metadata_file="envio/$deployment_indexer/indexer-info.json"
 
             if [ ! -s "$cache_file" ]; then
                 echo "❌ $cache_file is missing or empty" >&2
@@ -78,6 +80,15 @@ _deploy indexer:
             mkdir -p .envio
             cp -R "$cache_source" .envio/cache
             git add -A .envio/cache
+
+            deployment_timestamp=$(date -u '+%s')
+            jq \
+                --arg commitHash "$source_commit" \
+                --argjson deployedAt "$deployment_timestamp" \
+                '.commitHash = $commitHash | .deployedAt = $deployedAt' \
+                "$metadata_file" > "$metadata_file.tmp"
+            mv "$metadata_file.tmp" "$metadata_file"
+            git add "$metadata_file"
             ;;
     esac
 

--- a/schema/common/indexer-info.graphql
+++ b/schema/common/indexer-info.graphql
@@ -1,0 +1,50 @@
+"""
+Metadata describing the indexer deployment for one chain.
+"""
+type IndexerInfo @entity(immutable: true) {
+  """
+  The chain ID. There is one IndexerInfo entity per chain.
+  """
+  id: String!
+
+  """
+  The chain ID where this indexer is running.
+  """
+  chainId: BigInt!
+
+  """
+  Git commit from which the indexer was deployed.
+  """
+  commitHash: String!
+
+  """
+  Approximate Unix timestamp when the deployment was prepared. This may differ from the time at which the deployment
+  became active. Local deployments fall back to the timestamp of the first indexed block.
+  """
+  deployedAt: BigInt!
+
+  """
+  Public indexer key: "airdrops" or "streams".
+  """
+  indexer: String!
+
+  """
+  Protocols covered by this indexer.
+  """
+  protocols: [String!]!
+
+  """
+  First block processed by this indexer on the chain.
+  """
+  startBlock: BigInt!
+
+  """
+  Indexing service: "envio" or "graph".
+  """
+  vendor: String!
+
+  """
+  The Graph deployment version label. Unavailable for Envio deployments.
+  """
+  versionLabel: String
+}

--- a/schema/merger.ts
+++ b/schema/merger.ts
@@ -28,6 +28,7 @@ type ProtocolSchemaConfig = {
  * Base GraphQL definition files shared across all indexers.
  */
 const BASE = {
+  common: ["indexer-info"],
   generators: [getEnumDefs, getAssetDefs, getWatcherDefs],
 };
 
@@ -37,11 +38,12 @@ const BASE = {
 const PROTOCOL_MAP: Record<string, ProtocolSchemaConfig> = {
   analytics: {},
   airdrops: {
+    common: BASE.common,
     generators: BASE.generators,
     indexerSpecific: ["action", "activity", "campaign", "factory", "tranche"],
   },
   streams: {
-    common: ["contract", "deprecated-stream"],
+    common: [...BASE.common, "contract", "deprecated-stream"],
     generators: [...BASE.generators, getStreamDefs],
     indexerSpecific: ["segment", "tranche"],
   },

--- a/src/schemas/airdrops.graphql
+++ b/src/schemas/airdrops.graphql
@@ -68,6 +68,49 @@ type Watcher @entity(immutable: false) {
 }
 
 """
+Metadata describing the indexer deployment for one chain.
+"""
+type IndexerInfo @entity(immutable: true) {
+  """
+  The chain ID. There is one IndexerInfo entity per chain.
+  """
+  id: String!
+  """
+  The chain ID where this indexer is running.
+  """
+  chainId: BigInt!
+  """
+  Git commit from which the indexer was deployed.
+  """
+  commitHash: String!
+  """
+  Approximate Unix timestamp when the deployment was prepared. This may differ from the time at which the deployment
+  became active. Local deployments fall back to the timestamp of the first indexed block.
+  """
+  deployedAt: BigInt!
+  """
+  Public indexer key: "airdrops" or "streams".
+  """
+  indexer: String!
+  """
+  Protocols covered by this indexer.
+  """
+  protocols: [String!]!
+  """
+  First block processed by this indexer on the chain.
+  """
+  startBlock: BigInt!
+  """
+  Indexing service: "envio" or "graph".
+  """
+  vendor: String!
+  """
+  The Graph deployment version label. Unavailable for Envio deployments.
+  """
+  versionLabel: String
+}
+
+"""
 A generic entity for tracking protocol actions. There may be multiple actions for a single tx.
 """
 type Action @entity(immutable: true) {

--- a/src/schemas/streams.graphql
+++ b/src/schemas/streams.graphql
@@ -684,6 +684,49 @@ type LockupBatcher @entity(immutable: false) {
 }
 
 """
+Metadata describing the indexer deployment for one chain.
+"""
+type IndexerInfo @entity(immutable: true) {
+  """
+  The chain ID. There is one IndexerInfo entity per chain.
+  """
+  id: String!
+  """
+  The chain ID where this indexer is running.
+  """
+  chainId: BigInt!
+  """
+  Git commit from which the indexer was deployed.
+  """
+  commitHash: String!
+  """
+  Approximate Unix timestamp when the deployment was prepared. This may differ from the time at which the deployment
+  became active. Local deployments fall back to the timestamp of the first indexed block.
+  """
+  deployedAt: BigInt!
+  """
+  Public indexer key: "airdrops" or "streams".
+  """
+  indexer: String!
+  """
+  Protocols covered by this indexer.
+  """
+  protocols: [String!]!
+  """
+  First block processed by this indexer on the chain.
+  """
+  startBlock: BigInt!
+  """
+  Indexing service: "envio" or "graph".
+  """
+  vendor: String!
+  """
+  The Graph deployment version label. Unavailable for Envio deployments.
+  """
+  versionLabel: String
+}
+
+"""
 A Sablier protocol contract
 """
 type Contract @entity(immutable: false) {

--- a/tests/cli/graph-deploy-all.test.ts
+++ b/tests/cli/graph-deploy-all.test.ts
@@ -5,8 +5,36 @@ import {
   isTransientDeployFailure,
 } from "../../cli/commands/graph/deploy/all/run.js";
 import { extractDeployFailureMessage } from "../../cli/commands/graph/deploy/helpers.js";
+import { applyIndexerInfoMetadata } from "../../cli/commands/graph/deploy/indexer-info.js";
 
-describe("graph deploy retry helpers", () => {
+describe("graph deployment helpers", () => {
+  it("injects deployment metadata into the IndexerInfo source", () => {
+    const manifest = {
+      dataSources: [
+        {
+          name: "IndexerInfo",
+          context: {
+            commitHash: { data: "development" },
+            deployedAt: { data: "0" },
+            versionLabel: { data: "development" },
+          },
+        },
+      ],
+    };
+
+    applyIndexerInfoMetadata(manifest, {
+      commitHash: "abc123",
+      deployedAt: 1_753_987_200,
+      versionLabel: "v3.0--v1.0.0",
+    });
+
+    expect(manifest.dataSources[0]?.context).toEqual({
+      commitHash: { data: "abc123" },
+      deployedAt: { data: "1753987200" },
+      versionLabel: { data: "v3.0--v1.0.0" },
+    });
+  });
+
   it("detects transient deploy failures from rate limits and network errors", () => {
     expect(isTransientDeployFailure("Error: 429 Too Many Requests", "")).toBe(true);
     expect(isTransientDeployFailure("", "socket hang up while deploying")).toBe(true);


### PR DESCRIPTION
Adds one immutable `IndexerInfo` entity per chain across Envio and The Graph. It records the source commit, public indexer key, vendor, covered protocols, first indexed block, and an approximate deployment timestamp; Graph deployments also include their version label.

The deployment paths stamp this metadata at preparation time. Graph uses a temporary manifest so generated manifests stay deterministic, while Envio records the values in each deployment branch's preparation commit.

Validated with `na biome lint`, `just prettier-check`, `na tsc --noEmit`, `just envio::type-check`, `just test`, and `just graph::build-all`.

Closes #182
