### PR TITLE
chore: drop abstract from the graph indexers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+[7.0.0]: https://github.com/sablier-labs/indexers/compare/v6.0.0...v7.0.0
 [6.0.0]: https://github.com/sablier-labs/indexers/releases/tag/v6.0.0
 [5.1.0]: https://github.com/sablier-labs/indexers/compare/v5.0.0...v5.1.0
 [5.0.0]: https://github.com/sablier-labs/indexers/compare/v4.0.1...v5.0.0
@@ -17,6 +18,15 @@ The format is based on [Common Changelog](https://common-changelog.org/), and th
 [1.1.0]: https://github.com/sablier-labs/indexers/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/sablier-labs/indexers/releases/tag/v1.0.0
 [4716449]: https://github.com/sablier-labs/indexers/commit/4716449e
+
+## [7.0.0] - 2026-08-03
+
+### Removed
+
+- **Breaking:** Remove the Abstract (chain ID `2741`) `airdrops` and `streams` Graph indexers, following the end of
+  Abstract support by The Graph. `getIndexerGraph` and `getIndexer` with `vendor: "graph"` now return `undefined` for
+  Abstract, and the chain is no longer part of `graphChains` or the Graph deploy targets. Abstract remains fully
+  supported on Envio, so `getIndexerEnvio` is unaffected — consumers should read Abstract data through Envio
 
 ## [6.0.0] - 2026-07-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sablier/indexers",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "Data indexers for the Sablier Protocol",
   "homepage": "https://github.com/sablier-labs/indexers#readme",
   "license": "GPL-3.0-or-later",

--- a/src/indexers/graph.ts
+++ b/src/indexers/graph.ts
@@ -151,10 +151,6 @@ const OFFICIALS: ProtocolIndexerGraphMap[] = [
     airdrops: "DFD73EcSue44R7mpHvXeyvcgaT8tR1iKakZFjBsiFpjs",
     streams: "AvDAMYYHGaEwn9F9585uqq6MM5CfvRtYcb7KjK7LKPCt",
   }),
-  official(chains.abstract.id, {
-    airdrops: "DRrf6mYEhRt9QieKvTjDHnSWcBm3GW96hpedMKVxLABx",
-    streams: "2QjTdDFY233faXksUruMERMiDoQDdtGG5hBLC27aT1Pw",
-  }),
   official(chains.arbitrum.id, {
     airdrops: "HkHDg6NVVVeobhpcU4pTPMktyC25zd6xAQBGpYrWDgRr",
     streams: "yvDXXHSyv6rGPSzfpbBcbQmMFrECac3Q2zADkYsMxam",


### PR DESCRIPTION
The Graph no longer supports Abstract (chain ID 2741), so its airdrops and streams subgraph entries are removed from the registry in src/indexers/graph.ts. That file is the single source of truth, so this also drops Abstract from graphChains, manifest codegen, graph-deploy-all, the revive cron, and open-studio.

Abstract remains fully supported on Envio — src/indexers/envio.ts and the envio/*/config.yaml files are untouched, so getIndexerEnvio still serves the chain.

Breaking: getIndexerGraph({ chainId: 2741, … }) now returns undefined. Released as 7.0.0.

Verified: tsc --noEmit clean, biome lint clean, 131 unit tests pass (vendor tests excluded — they hit the network).